### PR TITLE
feat(cli): add version command and flags

### DIFF
--- a/cmd/helios-cli/cli_smoke_test.go
+++ b/cmd/helios-cli/cli_smoke_test.go
@@ -72,3 +72,17 @@ func TestCLI_Help(t *testing.T) {
 	}
 	_ = os.Stdout
 }
+
+func TestCLI_Version(t *testing.T) {
+    bin := filepath.Join(t.TempDir(), "helios-cli.testbin")
+    if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+        t.Fatalf("build failed: %v\n%s", err, string(out))
+    }
+    out, err := exec.Command(bin, "--version").CombinedOutput()
+    if err != nil {
+        t.Fatalf("--version failed: %v\n%s", err, string(out))
+    }
+    if len(out) == 0 {
+        t.Fatalf("version should print output")
+    }
+}

--- a/cmd/helios-cli/cli_smoke_test.go
+++ b/cmd/helios-cli/cli_smoke_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package main
 
 import (
@@ -74,15 +73,15 @@ func TestCLI_Help(t *testing.T) {
 }
 
 func TestCLI_Version(t *testing.T) {
-    bin := filepath.Join(t.TempDir(), "helios-cli.testbin")
-    if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-        t.Fatalf("build failed: %v\n%s", err, string(out))
-    }
-    out, err := exec.Command(bin, "--version").CombinedOutput()
-    if err != nil {
-        t.Fatalf("--version failed: %v\n%s", err, string(out))
-    }
-    if len(out) == 0 {
-        t.Fatalf("version should print output")
-    }
+	bin := filepath.Join(t.TempDir(), "helios-cli.testbin")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, string(out))
+	}
+	out, err := exec.Command(bin, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("--version failed: %v\n%s", err, string(out))
+	}
+	if len(out) == 0 {
+		t.Fatalf("version should print output")
+	}
 }

--- a/cmd/helios-cli/main.go
+++ b/cmd/helios-cli/main.go
@@ -16,46 +16,56 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"os"
+    "flag"
+    "fmt"
+    "os"
 
-	"github.com/good-night-oppie/helios-engine/cmd/helios-cli/internal/cli"
+    "github.com/good-night-oppie/helios-engine/cmd/helios-cli/internal/cli"
+)
+
+// Version metadata. Overridden at build time via -ldflags.
+var (
+    version = "dev"
+    commit  = "none"
+    date    = "unknown"
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		usage()
-		return
-	}
-	switch os.Args[1] {
-	case "commit":
-		handleCommit()
-	case "restore":
-		handleRestore()
-	case "diff":
-		handleDiff()
-	case "materialize":
-		handleMaterialize()
-	case "stats":
-		handleStats()
-	case "-h", "--help", "help":
-		usage()
-	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
-		usage()
-		os.Exit(2)
-	}
+    if len(os.Args) < 2 {
+        usage()
+        return
+    }
+    switch os.Args[1] {
+    case "commit":
+        handleCommit()
+    case "restore":
+        handleRestore()
+    case "diff":
+        handleDiff()
+    case "materialize":
+        handleMaterialize()
+    case "stats":
+        handleStats()
+    case "version", "--version", "-v":
+        handleVersion()
+    case "-h", "--help", "help":
+        usage()
+    default:
+        fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+        usage()
+        os.Exit(2)
+    }
 }
 
 func usage() {
-	fmt.Println(`helios-cli
+    fmt.Println(`helios-cli
 Commands:
   commit       --work <path>
   restore      --id <snapshotID>
   diff         --from <id> --to <id>
   materialize  --id <snapshotID> --out <dir> [--include <glob>] [--exclude <glob>]
-  stats`)
+  stats
+  version      [-v|--version]`)
 }
 
 // --- CLI configuration ---
@@ -125,10 +135,15 @@ func handleMaterialize() {
 }
 
 func handleStats() {
-	cfg := newConfig()
-	if err := cli.HandleStats(os.Stdout, cfg); err != nil {
-		die(err)
-	}
+    cfg := newConfig()
+    if err := cli.HandleStats(os.Stdout, cfg); err != nil {
+        die(err)
+    }
+}
+
+// handleVersion prints CLI version information.
+func handleVersion() {
+    fmt.Printf("helios %s (commit %s, built %s)\n", version, commit, date)
 }
 
 func die(err error) {

--- a/cmd/helios-cli/main.go
+++ b/cmd/helios-cli/main.go
@@ -12,53 +12,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package main
 
 import (
-    "flag"
-    "fmt"
-    "os"
+	"flag"
+	"fmt"
+	"os"
 
-    "github.com/good-night-oppie/helios-engine/cmd/helios-cli/internal/cli"
+	"github.com/good-night-oppie/helios-engine/cmd/helios-cli/internal/cli"
 )
 
 // Version metadata. Overridden at build time via -ldflags.
 var (
-    version = "dev"
-    commit  = "none"
-    date    = "unknown"
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 func main() {
-    if len(os.Args) < 2 {
-        usage()
-        return
-    }
-    switch os.Args[1] {
-    case "commit":
-        handleCommit()
-    case "restore":
-        handleRestore()
-    case "diff":
-        handleDiff()
-    case "materialize":
-        handleMaterialize()
-    case "stats":
-        handleStats()
-    case "version", "--version", "-v":
-        handleVersion()
-    case "-h", "--help", "help":
-        usage()
-    default:
-        fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
-        usage()
-        os.Exit(2)
-    }
+	if len(os.Args) < 2 {
+		usage()
+		return
+	}
+	switch os.Args[1] {
+	case "commit":
+		handleCommit()
+	case "restore":
+		handleRestore()
+	case "diff":
+		handleDiff()
+	case "materialize":
+		handleMaterialize()
+	case "stats":
+		handleStats()
+	case "version", "--version", "-v":
+		handleVersion()
+	case "-h", "--help", "help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
 }
 
 func usage() {
-    fmt.Println(`helios-cli
+	fmt.Println(`helios
 Commands:
   commit       --work <path>
   restore      --id <snapshotID>
@@ -135,15 +134,15 @@ func handleMaterialize() {
 }
 
 func handleStats() {
-    cfg := newConfig()
-    if err := cli.HandleStats(os.Stdout, cfg); err != nil {
-        die(err)
-    }
+	cfg := newConfig()
+	if err := cli.HandleStats(os.Stdout, cfg); err != nil {
+		die(err)
+	}
 }
 
 // handleVersion prints CLI version information.
 func handleVersion() {
-    fmt.Printf("helios %s (commit %s, built %s)\n", version, commit, date)
+	fmt.Printf("helios %s (commit %s, built %s)\n", version, commit, date)
 }
 
 func die(err error) {

--- a/cmd/helios-cli/main_test.go
+++ b/cmd/helios-cli/main_test.go
@@ -192,3 +192,27 @@ func TestMainCommandParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleVersion(t *testing.T) {
+    // Capture stdout to verify version prints a non-empty line.
+    old := os.Stdout
+    r, w, err := os.Pipe()
+    if err != nil {
+        t.Fatalf("pipe: %v", err)
+    }
+    os.Stdout = w
+
+    handleVersion()
+
+    _ = w.Close()
+    os.Stdout = old
+    buf := make([]byte, 256)
+    n, _ := r.Read(buf)
+    out := string(buf[:n])
+    if out == "" {
+        t.Fatal("expected version output")
+    }
+    if version == "" || commit == "" || date == "" {
+        t.Fatal("version metadata should be non-empty strings")
+    }
+}

--- a/cmd/helios-cli/main_test.go
+++ b/cmd/helios-cli/main_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package main
 
 import (
@@ -194,25 +193,25 @@ func TestMainCommandParsing(t *testing.T) {
 }
 
 func TestHandleVersion(t *testing.T) {
-    // Capture stdout to verify version prints a non-empty line.
-    old := os.Stdout
-    r, w, err := os.Pipe()
-    if err != nil {
-        t.Fatalf("pipe: %v", err)
-    }
-    os.Stdout = w
+	// Capture stdout to verify version prints a non-empty line.
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
 
-    handleVersion()
+	handleVersion()
 
-    _ = w.Close()
-    os.Stdout = old
-    buf := make([]byte, 256)
-    n, _ := r.Read(buf)
-    out := string(buf[:n])
-    if out == "" {
-        t.Fatal("expected version output")
-    }
-    if version == "" || commit == "" || date == "" {
-        t.Fatal("version metadata should be non-empty strings")
-    }
+	_ = w.Close()
+	os.Stdout = old
+	buf := make([]byte, 256)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+	if out == "" {
+		t.Fatal("expected version output")
+	}
+	if version == "" || commit == "" || date == "" {
+		t.Fatal("version metadata should be non-empty strings")
+	}
 }


### PR DESCRIPTION
Summary

  - Add version entry points to Helios CLI: version, --version, -v.

  Implementation

  - Introduce variables main.version, main.commit, main.date (overridable via ldflags).
  - Add handleVersion and wire into main switch.
  - Update usage text to include version.

  Build

  - Local build: go build -o bin/helios ./cmd/helios-cli
  - With metadata:
  go build -ldflags "-X 'main.version=v0.1.0' -X 'main.commit=$(git rev-parse --short HEAD)' -X
  'main.date=$(date -u +%Y-%m-%d)'" -o bin/helios ./cmd/helios-cli

  Tests

  - Add TestHandleVersion (unit) and TestCLI_Version (end-to-end binary invocation).
  - Run: make test or go test -race ./...
  - Scope: Only CLI files changed; no impact on stress/perf tests.

Reason to add two additional tests:

  - Prevent regressions: TestHandleVersion ensures the version path remains reachable and does not
  panic if the command routing changes.
  - End-to-end verification: TestCLI_Version builds the binary and runs --version to validate the
  full CLI stack (argument parsing → output).
  - Output contract: Both tests guarantee a non-empty version line so silent breakages are caught
  early.
  - Low overhead: Tests are fast, have no engine/storage dependencies, and fit well in routine CI.