### PR TITLE
Debug Code and Resolve Issues

### DIFF
--- a/cmd/helios-cli/internal/cli/cli.go
+++ b/cmd/helios-cli/internal/cli/cli.go
@@ -42,6 +42,7 @@ type Engine interface {
 	Materialize(id types.SnapshotID, outDir string, opts types.MatOpts) (types.CommitMetrics, error)
 	L1Stats() l1cache.CacheStats
 	EngineMetricsSnapshot() metrics.Snapshot
+	Close() error
 }
 
 // Config holds dependencies for CLI handlers
@@ -67,6 +68,7 @@ func HandleCommit(w io.Writer, cfg Config, workDir string) error {
 	if err != nil {
 		return err
 	}
+	defer eng.Close()
 
 	// Ingest current working directory into the engine before committing.
 	// This populates v.cur so that Commit() has real blobs to persist into L2.
@@ -133,6 +135,7 @@ func HandleRestore(w io.Writer, cfg Config, id string) error {
 	if err != nil {
 		return err
 	}
+	defer eng.Close()
 
 	if err := eng.Restore(types.SnapshotID(id)); err != nil {
 		return err
@@ -152,6 +155,7 @@ func HandleDiff(w io.Writer, cfg Config, from, to string) error {
 	if err != nil {
 		return err
 	}
+	defer eng.Close()
 
 	dr, err := eng.Diff(types.SnapshotID(from), types.SnapshotID(to))
 	if err != nil {
@@ -171,6 +175,7 @@ func HandleMaterialize(w io.Writer, cfg Config, id, outDir string, opts MatOpts)
 	if err != nil {
 		return err
 	}
+	defer eng.Close()
 
 	matOpts := types.MatOpts{
 		Include: opts.Include,
@@ -195,6 +200,7 @@ func HandleStats(w io.Writer, cfg Config) error {
 	if err != nil {
 		return err
 	}
+	defer eng.Close()
 
 	st := eng.L1Stats()
 	em := eng.EngineMetricsSnapshot()
@@ -223,7 +229,10 @@ func DefaultEngineFactory() (Engine, error) {
 	eng := vst.New()
 
 	// Attach a small L1 cache for observable stats
-	l1, _ := l1cache.New(l1cache.Config{CapacityBytes: 8 << 20, CompressionThreshold: 256})
+	l1, err := l1cache.New(l1cache.Config{CapacityBytes: 8 << 20, CompressionThreshold: 256})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create L1 cache: %w", err)
+	}
 
 	// Get store directory using the unified resolver
 	cwd, err := os.Getwd()

--- a/pkg/helios/cas/cas.go
+++ b/pkg/helios/cas/cas.go
@@ -305,30 +305,36 @@ func (s *BLAKE3Store) StoreBatch(contents [][]byte) ([]types.Hash, error) {
 		// Queue all writes together for better batching
 		for i, content := range contents {
 			filePath := filepath.Join(s.storePath, hashKeys[i])
-			
+
 			// Check if store is closed after acquiring lock
 			if atomic.LoadInt32(&s.closed) != 0 {
-				// Store is closed, write synchronously 
-				os.WriteFile(filePath, content, 0644) // Ignore error in batch mode
+				// Store is closed, write synchronously
+				if err := os.WriteFile(filePath, content, 0644); err != nil {
+					return hashes, fmt.Errorf("failed to write batch entry %d (%s) during close: %w", i, filePath, err)
+				}
 				continue
 			}
-			
+
 			// Critical: Add to WaitGroup BEFORE attempting to send to channel
 			// We hold shutdownMu.RLock so Close() cannot proceed until we're done
 			s.wg.Add(1)
-			
+
 			select {
 			case <-s.done:
 				// Store is shutting down, decrement WaitGroup and fallback to sync write
 				s.wg.Done()
-				os.WriteFile(filePath, content, 0644) // Ignore error in batch mode during shutdown
+				if err := os.WriteFile(filePath, content, 0644); err != nil {
+					return hashes, fmt.Errorf("failed to write batch entry %d (%s) during shutdown: %w", i, filePath, err)
+				}
 			case s.writeQueue <- writeOp{filePath: filePath, content: content}:
 				// Successfully queued
 			default:
 				// Queue full, must call Done() since we already called Add()
 				s.wg.Done()
 				// Fallback to sync write
-				os.WriteFile(filePath, content, 0644) // Ignore error in batch mode
+				if err := os.WriteFile(filePath, content, 0644); err != nil {
+					return hashes, fmt.Errorf("failed to write batch entry %d (%s): %w", i, filePath, err)
+				}
 			}
 		}
 	}

--- a/pkg/helios/vst/diff.go
+++ b/pkg/helios/vst/diff.go
@@ -16,6 +16,7 @@
 package vst
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/good-night-oppie/helios/pkg/helios/types"
@@ -23,14 +24,15 @@ import (
 
 // Diff compares two snapshots and returns Added/Changed/Deleted counts.
 func (v *VST) Diff(from, to types.SnapshotID) (types.DiffStats, error) {
-	fromSnap, ok := v.snaps[from]
-	if !ok {
-		return types.DiffStats{}, fmt.Errorf("unknown snapshot: %s", from)
+	// Try to get both snapshots (from memory or L2)
+	fromSnap, err := v.getSnapshot(from)
+	if err != nil {
+		return types.DiffStats{}, fmt.Errorf("failed to get 'from' snapshot %s: %w", from, err)
 	}
 
-	toSnap, ok := v.snaps[to]
-	if !ok {
-		return types.DiffStats{}, fmt.Errorf("unknown snapshot: %s", to)
+	toSnap, err := v.getSnapshot(to)
+	if err != nil {
+		return types.DiffStats{}, fmt.Errorf("failed to get 'to' snapshot %s: %w", to, err)
 	}
 
 	var stats types.DiffStats
@@ -55,4 +57,54 @@ func (v *VST) Diff(from, to types.SnapshotID) (types.DiffStats, error) {
 	}
 
 	return stats, nil
+}
+
+// getSnapshot retrieves a snapshot from memory or L2 store
+func (v *VST) getSnapshot(id types.SnapshotID) (map[string][]byte, error) {
+	// First try to get from memory
+	v.mu.RLock()
+	snap, ok := v.snaps[id]
+	v.mu.RUnlock()
+
+	if ok {
+		return snap, nil
+	}
+
+	// If not in memory and L2 is attached, try L2
+	if v.l2 != nil {
+		// Get snapshot metadata
+		snapshotKey := string("snapshot:" + id)
+		dprintf("getSnapshot: trying to get metadata with key %s", snapshotKey)
+		metadataHash := types.Hash{Algorithm: types.BLAKE3, Digest: []byte(snapshotKey)}
+		metadataBytes, ok, err := v.l2.Get(metadataHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch snapshot metadata from L2: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("snapshot not found in L2: %s", id)
+		}
+
+		// Unmarshal metadata
+		var snapshotData map[string]types.Hash
+		if err := json.Unmarshal(metadataBytes, &snapshotData); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal snapshot metadata: %w", err)
+		}
+
+		// Fetch file contents from L2
+		snap := make(map[string][]byte)
+		for path, hash := range snapshotData {
+			data, ok, err := v.l2.Get(hash)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get file %s from L2: %w", path, err)
+			}
+			if !ok {
+				return nil, fmt.Errorf("missing file data in L2 for %s", path)
+			}
+			snap[path] = data
+		}
+
+		return snap, nil
+	}
+
+	return nil, fmt.Errorf("snapshot not found: %s", id)
 }

--- a/pkg/helios/vst/materialize.go
+++ b/pkg/helios/vst/materialize.go
@@ -28,8 +28,17 @@ import (
 // Materialize writes the files from a snapshot to a real directory on disk.
 func (v *VST) Materialize(id types.SnapshotID, outDir string, opts types.MatOpts) (types.CommitMetrics, error) {
 	start := time.Now()
+
+	// Validate and canonicalize output directory to prevent path traversal
+	absOutDir, err := filepath.Abs(outDir)
+	if err != nil {
+		return types.CommitMetrics{}, fmt.Errorf("failed to get absolute path for output directory: %w", err)
+	}
+
 	// First try to get snapshot from memory
+	v.mu.RLock()
 	snap, ok := v.snaps[id]
+	v.mu.RUnlock()
 
 	// If not in memory, try L2
 	if !ok && v.l2 != nil {
@@ -76,11 +85,27 @@ func (v *VST) Materialize(id types.SnapshotID, outDir string, opts types.MatOpts
 			continue
 		}
 
-		dst := filepath.Join(outDir, path)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		// Validate path to prevent directory traversal attacks
+		if err := validatePath(path); err != nil {
+			return types.CommitMetrics{}, fmt.Errorf("invalid path in snapshot %s: %w", path, err)
+		}
+
+		dst := filepath.Join(absOutDir, path)
+
+		// Double-check that the resolved destination is within outDir
+		// This prevents path traversal via symlinks or other tricks
+		absDst, err := filepath.Abs(dst)
+		if err != nil {
+			return types.CommitMetrics{}, fmt.Errorf("failed to resolve destination path: %w", err)
+		}
+		if !isSubpath(absOutDir, absDst) {
+			return types.CommitMetrics{}, fmt.Errorf("path traversal detected: %s would escape output directory", path)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(absDst), 0o755); err != nil {
 			return types.CommitMetrics{}, err
 		}
-		if err := os.WriteFile(dst, content, 0o644); err != nil {
+		if err := os.WriteFile(absDst, content, 0o644); err != nil {
 			return types.CommitMetrics{}, err
 		}
 		bytesTotal += int64(len(content))
@@ -134,4 +159,37 @@ func matchGlob(path, pattern string) bool {
 	// Use filepath.Match for other patterns
 	matched, _ := filepath.Match(pattern, path)
 	return matched
+}
+
+// validatePath checks if a path is safe (doesn't contain path traversal attempts)
+func validatePath(path string) error {
+	// Reject absolute paths
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("absolute paths not allowed: %s", path)
+	}
+
+	// Clean the path to normalize it
+	cleaned := filepath.Clean(path)
+
+	// Check for path traversal attempts
+	if cleaned == ".." || filepath.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path traversal detected: %s", path)
+	}
+
+	return nil
+}
+
+// isSubpath checks if child is a subdirectory or file within parent
+func isSubpath(parent, child string) bool {
+	// Clean and make paths absolute for reliable comparison
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+
+	// Add trailing separator to parent to avoid false positives
+	// e.g., /foo should not match /foobar
+	if !filepath.HasSuffix(parent, string(filepath.Separator)) {
+		parent += string(filepath.Separator)
+	}
+
+	return filepath.HasPrefix(child+string(filepath.Separator), parent)
 }

--- a/pkg/helios/vst/vst.go
+++ b/pkg/helios/vst/vst.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/good-night-oppie/helios/internal/metrics"
@@ -50,6 +51,7 @@ type VST struct {
 	l2         objstore.Store                         // L2 persistent store
 	pathToHash map[string]types.Hash                  // path -> content hash mapping for L1/L2 retrieval
 	em         *metrics.EngineMetrics                 // engine metrics collector
+	mu         sync.RWMutex                           // protects cur, pathToHash, and snaps
 }
 
 // New returns a fresh VST.
@@ -75,20 +77,28 @@ func (v *VST) AttachStores(l1 l1cache.Cache, l2 objstore.Store) {
 func (v *VST) WriteFile(path string, content []byte) error {
 	cp := make([]byte, len(content))
 	copy(cp, content)
+	v.mu.Lock()
 	v.cur[path] = cp
+	v.mu.Unlock()
 	return nil
 }
 
 // DeleteFile removes a file from the current working set.
 func (v *VST) DeleteFile(path string) {
+	v.mu.Lock()
 	delete(v.cur, path)
+	v.mu.Unlock()
 }
 
 // ReadFile reads a file from the current working set (copy returned).
 // If the file is not in memory but we have stores attached, it tries L1 then L2.
 func (v *VST) ReadFile(path string) ([]byte, error) {
 	// First check current working set
+	v.mu.RLock()
 	b, ok := v.cur[path]
+	hash, hasHash := v.pathToHash[path]
+	v.mu.RUnlock()
+
 	if ok {
 		cp := make([]byte, len(b))
 		copy(cp, b)
@@ -96,7 +106,6 @@ func (v *VST) ReadFile(path string) ([]byte, error) {
 	}
 
 	// Try to get from L1/L2 using stored hash
-	hash, hasHash := v.pathToHash[path]
 	if !hasHash {
 		return nil, nil // File doesn't exist
 	}
@@ -134,6 +143,7 @@ func (v *VST) Commit(msg string) (types.SnapshotID, types.CommitMetrics, error) 
 	start := time.Now()
 
 	// Deep copy current working set for the stored snapshot (restore/materialize rely on this).
+	v.mu.RLock()
 	snap := make(map[string][]byte, len(v.cur))
 	var newBytes int64
 	for k, val := range v.cur {
@@ -142,22 +152,21 @@ func (v *VST) Commit(msg string) (types.SnapshotID, types.CommitMetrics, error) 
 		snap[k] = cp
 		newBytes += int64(len(cp))
 	}
+	v.mu.RUnlock()
 
 	// Compute Merkle root over the current working set.
 	// Algorithm:
 	//  1) For each file path -> hash blob(content)
 	//  2) Aggregate bottom-up by directory: "name:type:childHash"
 	//  3) The root (".") tree hash becomes SnapshotID
-	blobHashByPath := make(map[string]types.Hash, len(v.cur))
-	blobsToStore := make([]objstore.BatchEntry, 0, len(v.cur))
-	for path, content := range v.cur {
+	blobHashByPath := make(map[string]types.Hash, len(snap))
+	blobsToStore := make([]objstore.BatchEntry, 0, len(snap))
+	for path, content := range snap {
 		h, err := util.HashBlob(content)
 		if err != nil {
 			return "", types.CommitMetrics{}, err
 		}
 		blobHashByPath[path] = h
-		// Store path->hash mapping for L1/L2 retrieval
-		v.pathToHash[path] = h
 
 		// Prepare for L2 storage if attached
 		if v.l2 != nil {
@@ -167,6 +176,13 @@ func (v *VST) Commit(msg string) (types.SnapshotID, types.CommitMetrics, error) 
 			})
 		}
 	}
+
+	// Store path->hash mapping for L1/L2 retrieval (must be done with lock)
+	v.mu.Lock()
+	for path, h := range blobHashByPath {
+		v.pathToHash[path] = h
+	}
+	v.mu.Unlock()
 
 	// Store blobs in L2 if attached
 	dprintf("commit: l2-attached=%v, blobsToStore=%d", v.l2 != nil, len(blobsToStore))
@@ -308,7 +324,9 @@ func (v *VST) Commit(msg string) (types.SnapshotID, types.CommitMetrics, error) 
 	}
 
 	// Store the snapshot by content (keeps your existing restore/materialize/diff working)
+	v.mu.Lock()
 	v.snaps[id] = snap
+	v.mu.Unlock()
 
 	commitMetrics := types.CommitMetrics{
 		CommitLatency: time.Since(start),
@@ -346,16 +364,19 @@ func (v *VST) Restore(id types.SnapshotID) error {
 // - DryRun: when true, only restores to memory without filesystem writes
 // - WriteToFilesystem: when true (default), writes restored files to disk atomically
 func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error {
-	dprintf("starting restore of snapshot %s (in-memory snapshots=%+v)", id, v.snaps)
+	v.mu.RLock()
 	base, ok := v.snaps[id]
-	if !ok && v.l2 == nil {
-		return fmt.Errorf("unknown snapshot: %s", id)
-	}
-	
+	dprintf("starting restore of snapshot %s (in-memory snapshots=%d)", id, len(v.snaps))
+
 	// Save the old tracked files before they get overwritten (for stale file cleanup)
 	oldTrackedFiles := make(map[string]bool)
 	for path := range v.cur {
 		oldTrackedFiles[path] = true
+	}
+	v.mu.RUnlock()
+
+	if !ok && v.l2 == nil {
+		return fmt.Errorf("unknown snapshot: %s", id)
 	}
 	
 	// Prepare the content to restore
@@ -398,10 +419,12 @@ func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error
 				}
 				restoredContent[path] = data
 			}
-			
+
 			// Reset working state and use snapshot metadata as path→hash mapping
+			v.mu.Lock()
 			v.cur = restoredContent
 			v.pathToHash = snapshotData
+			v.mu.Unlock()
 		}
 	} else {
 		// Copy in-memory snapshot to working set
@@ -411,7 +434,7 @@ func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error
 			cp := make([]byte, len(val))
 			copy(cp, val)
 			next[k] = cp
-			
+
 			// Always compute hash for in-memory snapshot files
 			h, err := util.HashBlob(val)
 			if err != nil {
@@ -419,8 +442,10 @@ func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error
 			}
 			pathHashes[k] = h
 		}
+		v.mu.Lock()
 		v.cur = next
 		v.pathToHash = pathHashes
+		v.mu.Unlock()
 		restoredContent = next
 	}
 	
@@ -504,4 +529,12 @@ func (v *VST) EngineMetricsSnapshot() metrics.Snapshot {
 		return metrics.Snapshot{}
 	}
 	return v.em.Snapshot()
+}
+
+// Close releases resources, including closing the L2 store if attached.
+func (v *VST) Close() error {
+	if v.l2 != nil {
+		return v.l2.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
…rity issues

This commit addresses multiple critical and high-severity bugs found during codebase analysis:

## Critical Fixes (HIGH Severity)

### 1. L2 Store Resource Leak (cli.go)
- **Issue**: PebbleDB store was never closed after CLI command execution
- **Impact**: File descriptor exhaustion and memory leaks under high-frequency operations
- **Fix**:
  - Added Close() method to Engine interface
  - Implemented Close() in VST to properly close L2 store
  - Added defer eng.Close() in all CLI handlers (Commit, Restore, Diff, Materialize, Stats)

### 2. Race Condition on pathToHash Map (vst.go)
- **Issue**: Concurrent access to pathToHash and cur maps without synchronization
- **Impact**: Potential panic with "concurrent map iteration and map write" under concurrent access
- **Fix**:
  - Added sync.RWMutex to VST struct to protect cur, pathToHash, and snaps
  - Protected all read/write operations with appropriate locks (RLock for reads, Lock for writes)
  - Methods updated: WriteFile, DeleteFile, ReadFile, Commit, RestoreWithOpts, Materialize, getSnapshot

## Medium Severity Fixes

### 3. Silently Ignored Write Failures in CAS Batch Mode (cas.go)
- **Issue**: Write errors in StoreBatch() were silently discarded (lines 312, 324, 331)
- **Impact**: Silent data loss when disk is full or permissions denied
- **Fix**: Added proper error checking and return for all os.WriteFile calls in batch operations

### 4. L1 Cache Error Handling (cli.go)
- **Issue**: Error from l1cache.New() was silently ignored with blank identifier
- **Impact**: Could continue with nil L1 cache on initialization failure
- **Fix**: Added proper error checking and return if L1 cache creation fails

### 5. Path Traversal Validation in Materialize (materialize.go)
- **Issue**: No validation of snapshot paths could allow escape from output directory
- **Impact**: Security vulnerability - paths like "../../../etc/passwd" could write outside intended directory
- **Fix**:
  - Added validatePath() to check for path traversal attempts and absolute paths
  - Added isSubpath() to verify resolved destination is within output directory
  - Validate paths before writing in Materialize()

### 6. Diff() L2 Support (diff.go)
- **Issue**: Diff() only worked with in-memory snapshots, failed for L2-stored snapshots
- **Impact**: Cannot diff old snapshots after memory eviction
- **Fix**:
  - Added getSnapshot() helper to fetch snapshots from memory or L2
  - Updated Diff() to use getSnapshot() for both 'from' and 'to' snapshots
  - Now supports diffing any snapshot in memory or L2 store

## Testing
- All existing tests pass (except one pre-existing performance test)
- Code compiles successfully
- No new compilation errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)