### PR TITLE
feat(ffi): CGO c-archive + Rust bindings for ionq Vector A (P0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,13 @@ bin/
 *.so
 *.dylib
 
+# FFI bridge build artefacts (cgo c-archive + cgo-generated header + C smoke binary)
+bindings/c/libhelios.a
+bindings/c/libhelios.h
+bindings/c/smoke
+bindings/rust/target/
+bindings/rust/Cargo.lock
+
 # Test outputs
 test-results/
 playwright-report/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test cover lint clean build build-all-platforms release-check release-tag docker-build install dev-setup
+.PHONY: all test cover lint clean build build-all-platforms release-check release-tag docker-build install dev-setup ffi-archive ffi-smoke rust-build rust-test rust-smoke
 
 GO := /usr/local/go/bin/go
 PKGS_CORE := $(shell go list ./internal/... ./pkg/... ./cmd/helios-cli/internal/cli)
@@ -95,11 +95,37 @@ docker-push:
 	docker push ghcr.io/good-night-oppie/helios:$(VERSION)
 	docker push ghcr.io/good-night-oppie/helios:latest
 
+# FFI bridge — c-archive + curated header + C smoke test
+ffi-archive:
+	@echo "--- Building libhelios.a (c-archive) ---"
+	@mkdir -p bindings/c
+	CGO_ENABLED=1 $(GO) build -buildmode=c-archive -o bindings/c/libhelios.a ./cmd/heliosffi
+
+ffi-smoke: ffi-archive
+	@echo "--- Building + running C smoke test ---"
+	cc -O2 -o bindings/c/smoke bindings/c/smoke.c bindings/c/libhelios.a -lpthread -ldl
+	./bindings/c/smoke
+
+# Rust bindings (helios-sys raw + helios-rs safe wrapper)
+rust-build: ffi-archive
+	@echo "--- Building Rust bindings ---"
+	cd bindings/rust && cargo build --release
+
+rust-test: ffi-archive
+	@echo "--- Running Rust binding tests ---"
+	cd bindings/rust && cargo test --release
+
+rust-smoke: ffi-archive
+	@echo "--- Running Rust helios_smoke example ---"
+	cd bindings/rust && cargo run --release --example helios_smoke
+
 # Cleanup
 clean:
 	@echo "--- Cleaning up ---"
 	rm -f coverage.out
 	rm -rf $(BUILD_DIR)
+	rm -f bindings/c/libhelios.a bindings/c/libhelios.h bindings/c/smoke
+	rm -rf bindings/rust/target
 	docker rmi ghcr.io/good-night-oppie/helios:$(VERSION) 2>/dev/null || true
 	docker rmi ghcr.io/good-night-oppie/helios:latest 2>/dev/null || true
 
@@ -118,5 +144,10 @@ help:
 	@echo "  release-notes       - Generate release notes (set TAG=v1.0.0)"
 	@echo "  docker-build        - Build Docker image"
 	@echo "  docker-push         - Push Docker image"
+	@echo "  ffi-archive         - Build libhelios.a c-archive (CGO export)"
+	@echo "  ffi-smoke           - Build + run C smoke test against libhelios.a"
+	@echo "  rust-build          - Build Rust bindings (helios-sys + helios-rs)"
+	@echo "  rust-test           - Run Rust binding unit tests"
+	@echo "  rust-smoke          - Run cargo run --example helios_smoke"
 	@echo "  clean               - Clean up build artifacts"
 	@echo "  help                - Show this help message"

--- a/README.md
+++ b/README.md
@@ -166,6 +166,38 @@ for experiment in range(100):
 - **CodeT5/StarCoder**: Version all generated variants
 - **Custom LLM workflows**: Drop-in replacement for Git commands
 
+### In-process Rust bindings (for hot agent loops)
+
+For multi-agent runtimes that cannot afford subprocess overhead per iteration,
+Helios exposes a CGO c-archive (`cmd/heliosffi`) and a safe Rust wrapper
+(`bindings/rust/helios-rs`) over the VST + VFSFork primitives.
+
+```bash
+# Build the c-archive (libhelios.a + libhelios.h)
+make ffi-archive
+
+# Run the Rust round-trip smoke test (~init→commit→fork→merge in microseconds)
+make rust-smoke
+```
+
+```rust
+use helios_rs::{BranchId, Vst};
+
+let v = Vst::new();
+v.write_file("agent.py", b"print('iter 0')")?;
+let base = v.commit("seed")?;
+let branch: BranchId = "main".into();
+v.create_branch(&branch, &base)?;
+
+// Propose without committing: fork-write-merge-or-discard
+let fork = v.fork(&base)?;
+fork.write("agent.py", b"print('iter 1')")?;
+let new_id = fork.merge_into(&branch).map_err(|(_, e)| e)?;
+```
+
+See [`docs/ionq-integration.md`](docs/ionq-integration.md) for the full FFI
+contract, error code table, and ionq Vector A/B integration notes.
+
 ## System Requirements
 
 - **OS**: Linux, macOS, or Windows  

--- a/TECHNICAL_REPORT.md
+++ b/TECHNICAL_REPORT.md
@@ -206,6 +206,78 @@ func (v *VST) CreateBranch(baseSnapshot SnapshotID) SnapshotID {
 
 **Why these optimizations matter for AI**: Reduces commit time from ~173μs to ~70μs, enabling 14,000+ commits per second for high-frequency AI experimentation.
 
+## In-process Primitives for Multi-Agent Runtimes
+
+Subprocess-per-checkpoint (the CLI path) is too expensive for hot agent loops
+that run thousands of iterations per second. Helios ships two in-process
+primitives consumed by runtimes like ionq:
+
+### 1. CGO c-archive + Rust bindings (Vector A, P0.1)
+
+`go build -buildmode=c-archive ./cmd/heliosffi` produces `libhelios.a` +
+`libhelios.h`. The exported uint64 opaque-handle ABI covers VST lifecycle,
+working-set I/O, commit/restore, branches, and the Fork primitive below.
+
+The Rust workspace at `bindings/rust/` ships:
+
+- `helios-sys` — handwritten `extern "C"` declarations (no bindgen dep).
+- `helios-rs` — safe wrapper with `Vst` / `Fork` / `SnapshotId` types,
+  `thiserror`-backed error enum, lifetime-bound forks, and Drop-on-discard.
+
+Measured per-op latency from the Rust example
+(`bindings/rust/examples/helios_smoke.rs`, Intel Xeon 8259CL, release):
+
+| Op                     | Wall |
+|------------------------|------|
+| `Vst::new` (warm)      |  2 µs |
+| `commit` (1 file)      | 80 µs |
+| `fork`                 |  3 µs |
+| `fork.write` (overlay) |  2 µs |
+| `fork.merge_into`      | 17 µs |
+| `restore` (in-memory)  |  3 µs |
+
+### 2. VFSFork overlay primitive (Vector B, P0.2)
+
+`pkg/helios/vst/fork.go` adds a copy-on-write overlay on top of an immutable
+base SnapshotID. Fork writes stay in RAM (no RocksDB I/O) until
+`MergeInto(branch)` succeeds via an atomic compare-and-swap on a named
+branch head. Loser forks see `ErrBranchStale` and may rebase + retry; the
+fork is not consumed on a failed merge.
+
+API surface (in `package vst`):
+
+```go
+type BranchID string
+type Change   struct { Path string; Kind ChangeKind; OldHash, NewHash types.Hash }
+
+func (v *VST) Fork(base SnapshotID) (*Fork, error)
+func (v *VST) CreateBranch(name BranchID, head SnapshotID) error
+func (v *VST) BranchHead(name BranchID) (SnapshotID, bool)
+
+func (f *Fork) Read(path string)  ([]byte, error)
+func (f *Fork) Write(path, content []byte) error
+func (f *Fork) Delete(path string) error
+func (f *Fork) Diff() []Change
+func (f *Fork) MergeInto(branch BranchID) (SnapshotID, error)  // CAS or ErrBranchStale
+func (f *Fork) Discard()                                       // mandatory; finalizer fallback
+```
+
+Acceptance microbench (in `fork_bench_test.go`):
+
+| Bench                          | Wall   | Target |
+|--------------------------------|--------|--------|
+| `Fork`+`Write`+`Discard`       | 1.3 µs | ≤ 50 µs |
+| `MergeInto` (in-mem)           | 7.7 µs | ≤ 100 µs |
+| Read passthrough (overlay miss)| 59 ns  | —       |
+
+Concurrency guarantees are validated by `TestFork_ParallelDivergent`
+(32 forks × 100 ops on disjoint branches, `-race` clean) and
+`TestFork_ParallelSameBranchCAS` (16 racers competing on the same branch
+with rebase-retry; exactly K winners).
+
+See `docs/ionq-integration.md` for the full FFI contract, error code
+table, and ownership / threading rules.
+
 ## Practical AI Integration Patterns
 
 ### The Standard AI Agent Workflow

--- a/bindings/c/helios.h
+++ b/bindings/c/helios.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Oppie Thunder Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * helios.h — stable C ABI for in-process Helios consumers.
+ *
+ * This file is the human-curated face of the FFI surface. It pulls in the
+ * cgo-generated libhelios.h (which declares the exported helios_* functions)
+ * and adds the stable error-code constants + ownership/threading contract.
+ *
+ * Build artefacts:
+ *   libhelios.a   — c-archive produced by `go build -buildmode=c-archive`
+ *   libhelios.h   — cgo-generated function declarations
+ *   helios.h      — this curated header (include this from C / bindgen)
+ *
+ * Ownership rules (see cmd/heliosffi/main.go docstring for details):
+ *   - Handles (helios_vst_t, helios_fork_t) are opaque uint64 values, NOT
+ *     pointers. Use 0 to mean "no handle" (helios_vst_new never returns 0
+ *     on success; check by calling a follow-up op and checking error code).
+ *   - All output byte buffers (uchar*) are allocated by Helios via malloc
+ *     and MUST be released with helios_buffer_free.
+ *   - All output strings (char*) are NUL-terminated and MUST be released
+ *     with helios_string_free.
+ *   - The library is safe for concurrent use across goroutines AND across
+ *     OS threads (the underlying VST is goroutine-safe; the FFI registry
+ *     uses sync.Map). Distinct fork handles may be driven in parallel.
+ */
+
+#ifndef HELIOS_H
+#define HELIOS_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Pull in the cgo-generated function declarations. */
+#include "libhelios.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle types. Currently uint64 backed by a process-global registry. */
+typedef uint64_t helios_vst_t;
+typedef uint64_t helios_fork_t;
+
+/* Error codes. Stable wire values; do not reorder. */
+#define HELIOS_OK                  ( 0)
+#define HELIOS_E_INVALID_ARG       (-1)
+#define HELIOS_E_INVALID_HANDLE    (-2)
+#define HELIOS_E_NOT_FOUND         (-3)
+#define HELIOS_E_INTERNAL          (-4)
+#define HELIOS_E_BRANCH_STALE      (-5)
+#define HELIOS_E_FORK_MERGED       (-6)
+#define HELIOS_E_FORK_DISCARDED    (-7)
+#define HELIOS_E_BRANCH_EXISTS     (-8)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HELIOS_H */

--- a/bindings/c/smoke.c
+++ b/bindings/c/smoke.c
@@ -1,0 +1,98 @@
+/*
+ * smoke.c — end-to-end smoke test for libhelios.a.
+ *
+ * Build (from repo root, after `go build -buildmode=c-archive ...`):
+ *   cc -o bindings/c/smoke bindings/c/smoke.c bindings/c/libhelios.a \
+ *      -lpthread -ldl
+ *
+ * Verifies: new -> write -> commit -> branch -> fork -> overlay write ->
+ * merge -> branch head advanced -> free. Exits 0 on success, non-zero on fail.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "helios.h"
+
+#define CHECK(expr, msg)                                                   \
+	do {                                                                   \
+		int _rc = (expr);                                                  \
+		if (_rc != HELIOS_OK) {                                            \
+			fprintf(stderr, "FAIL %s: rc=%d\n", msg, _rc);                 \
+			return 1;                                                      \
+		}                                                                  \
+	} while (0)
+
+int main(void) {
+	helios_vst_t v = helios_vst_new();
+	if (v == 0) { fprintf(stderr, "FAIL vst_new returned 0\n"); return 1; }
+
+	const char seed[] = "hello, ionq";
+	CHECK(helios_vst_write_file(v, (char*)"greeting.txt",
+	                            (unsigned char*)seed, strlen(seed)),
+	      "vst_write_file");
+
+	/* Read it back. */
+	unsigned char *buf = NULL; size_t buflen = 0;
+	CHECK(helios_vst_read_file(v, (char*)"greeting.txt", &buf, &buflen),
+	      "vst_read_file");
+	if (buflen != strlen(seed) || memcmp(buf, seed, buflen) != 0) {
+		fprintf(stderr, "FAIL read mismatch (%zu bytes)\n", buflen);
+		return 1;
+	}
+	helios_buffer_free(buf);
+
+	/* Commit. */
+	char *snap_id = NULL; size_t snap_len = 0;
+	CHECK(helios_vst_commit(v, (char*)"seed", &snap_id, &snap_len), "vst_commit");
+
+	/* Create a branch at that snapshot. */
+	CHECK(helios_vst_create_branch(v, (char*)"main", snap_id, snap_len),
+	      "vst_create_branch");
+
+	/* Fork off the branch head. */
+	helios_fork_t f = 0;
+	CHECK(helios_fork_new(v, snap_id, snap_len, &f), "fork_new");
+	if (f == 0) { fprintf(stderr, "FAIL fork_new returned 0\n"); return 1; }
+
+	const char payload[] = "overlay payload";
+	CHECK(helios_fork_write(f, (char*)"overlay.txt",
+	                        (unsigned char*)payload, strlen(payload)),
+	      "fork_write");
+
+	/* Read overlay value through the fork. */
+	unsigned char *fbuf = NULL; size_t flen = 0;
+	CHECK(helios_fork_read(f, (char*)"overlay.txt", &fbuf, &flen),
+	      "fork_read overlay");
+	if (flen != strlen(payload) || memcmp(fbuf, payload, flen) != 0) {
+		fprintf(stderr, "FAIL fork read overlay mismatch\n");
+		return 1;
+	}
+	helios_buffer_free(fbuf);
+
+	/* Merge into branch. */
+	char *new_id = NULL; size_t new_len = 0;
+	CHECK(helios_fork_merge_into(f, (char*)"main", &new_id, &new_len),
+	      "fork_merge_into");
+
+	/* Verify head advanced. */
+	char *head = NULL; size_t head_len = 0;
+	CHECK(helios_vst_branch_head(v, (char*)"main", &head, &head_len),
+	      "vst_branch_head");
+	if (head_len != new_len || memcmp(head, new_id, head_len) != 0) {
+		fprintf(stderr, "FAIL branch head != merged id\n");
+		return 1;
+	}
+	if (head_len == snap_len && memcmp(head, snap_id, head_len) == 0) {
+		fprintf(stderr, "FAIL branch head did not advance\n");
+		return 1;
+	}
+
+	helios_string_free(head);
+	helios_string_free(new_id);
+	helios_string_free(snap_id);
+
+	CHECK(helios_vst_free(v), "vst_free");
+	printf("OK\n");
+	return 0;
+}

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,0 +1,23 @@
+[workspace]
+members = ["helios-sys"]
+resolver = "2"
+
+[package]
+name = "helios-rs"
+version = "0.1.0"
+edition = "2021"
+description = "Safe Rust bindings for Helios VST + VFSFork primitives (ionq Vector A/B)"
+license = "Apache-2.0"
+repository = "https://github.com/good-night-oppie/helios"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[[example]]
+name = "helios_smoke"
+path = "examples/helios_smoke.rs"
+
+[dependencies]
+helios-sys = { path = "helios-sys", version = "0.1.0" }
+thiserror = "1"

--- a/bindings/rust/examples/helios_smoke.rs
+++ b/bindings/rust/examples/helios_smoke.rs
@@ -1,0 +1,109 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// helios_smoke — round-trip + microbench for the Helios Rust bindings.
+//
+// Run from this directory:
+//   cargo run --release --example helios_smoke
+//
+// Output: a per-op latency summary for init -> write -> commit -> branch ->
+// fork -> overlay write -> merge -> checkout. Acceptance target: every op
+// in this cycle completes in under 1ms.
+
+use std::time::Instant;
+
+use helios_rs::{BranchId, Vst};
+
+fn measure<F: FnOnce() -> R, R>(label: &str, f: F) -> R {
+    let t0 = Instant::now();
+    let r = f();
+    let dt = t0.elapsed();
+    let micros = dt.as_secs_f64() * 1_000_000.0;
+    let status = if dt.as_micros() < 1_000 { "OK " } else { "WARN" };
+    println!("  {status}  {label:<28} {micros:>8.2} us");
+    r
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Helios Rust bindings smoke test");
+    println!("--------------------------------");
+
+    // Warm up the cgo runtime so the first measured op doesn't pay the Go
+    // runtime init cost (~5ms, amortised once per process).
+    {
+        let _warmup = Vst::new();
+    }
+
+    let v = measure("init (Vst::new, warm)", Vst::new);
+
+    measure("write seed", || {
+        v.write_file("seed.txt", b"ionq codex agents").unwrap()
+    });
+
+    let base = measure("commit", || v.commit("seed").unwrap());
+    println!("  base snapshot id: {base}");
+
+    let branch: BranchId = "main".into();
+    measure("create_branch(main)", || {
+        v.create_branch(&branch, &base).unwrap()
+    });
+
+    let fork = measure("fork", || v.fork(&base).unwrap());
+    measure("fork write overlay", || {
+        fork.write("overlay.txt", b"proposed payload").unwrap()
+    });
+    let _ = measure("fork read passthrough", || {
+        fork.read("seed.txt").unwrap()
+    });
+    let new_id = measure("fork.merge_into(main)", || {
+        fork.merge_into(&branch).map_err(|(_, e)| e).unwrap()
+    });
+    println!("  merged snapshot id: {new_id}");
+
+    let head = measure("branch_head(main)", || {
+        v.branch_head(&branch).unwrap().unwrap()
+    });
+    assert_eq!(head, new_id, "branch head should equal merged id");
+
+    measure("restore (in-memory)", || v.restore(&new_id).unwrap());
+    let got = measure("read after restore", || {
+        v.read_file("overlay.txt").unwrap().unwrap()
+    });
+    assert_eq!(got, b"proposed payload");
+
+    // K-fork divergence: drive several concurrent overlays in series and
+    // confirm CAS semantics across rebases.
+    println!("\nCAS rebase loop:");
+    let head = v.branch_head(&branch).unwrap().unwrap();
+    let f1 = v.fork(&head).unwrap();
+    let f2 = v.fork(&head).unwrap();
+    f1.write("racer.txt", b"f1 wins").unwrap();
+    f2.write("racer.txt", b"f2 wins").unwrap();
+    let _ = measure("f1.merge_into", || {
+        f1.merge_into(&branch).map_err(|(_, e)| e).unwrap()
+    });
+    // f2 must see BranchStale and remain usable.
+    let result = measure("f2.merge_into (stale)", || f2.merge_into(&branch));
+    match result {
+        Err((f2_alive, helios_rs::Error::BranchStale)) => {
+            println!("  rebasing f2 onto new head and retrying...");
+            f2_alive.discard();
+            let new_head = v.branch_head(&branch).unwrap().unwrap();
+            let f2b = v.fork(&new_head).unwrap();
+            f2b.write("racer.txt", b"f2 retry").unwrap();
+            let _ = measure("f2.merge_into (retry)", || {
+                f2b.merge_into(&branch).map_err(|(_, e)| e).unwrap()
+            });
+        }
+        Ok(_) => panic!("expected BranchStale on f2"),
+        Err((_, e)) => return Err(Box::new(e)),
+    }
+
+    println!("\nOK — every op completed; acceptance gate (<1ms per op) reported above.");
+    Ok(())
+}

--- a/bindings/rust/helios-sys/Cargo.toml
+++ b/bindings/rust/helios-sys/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "helios-sys"
+version = "0.1.0"
+edition = "2021"
+description = "Raw FFI declarations for Helios c-archive (cmd/heliosffi)"
+license = "Apache-2.0"
+publish = false
+links = "helios"
+build = "build.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]

--- a/bindings/rust/helios-sys/build.rs
+++ b/bindings/rust/helios-sys/build.rs
@@ -1,0 +1,89 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// build.rs — produce libhelios.a via `go build -buildmode=c-archive` if the
+// artefact is not already present, then emit cargo link directives.
+//
+// The Go toolchain is invoked from the repo root (three levels up from this
+// crate). The output path is bindings/c/libhelios.a relative to the repo root.
+//
+// Environment overrides:
+//   HELIOS_FFI_LIB_DIR  — search directory containing libhelios.a (skips build)
+//   HELIOS_GO_BIN       — path to `go` binary (defaults to PATH lookup)
+//   HELIOS_SKIP_GO_BUILD=1 — assume libhelios.a already exists
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = .../bindings/rust/helios-sys
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    manifest_dir
+        .ancestors()
+        .nth(3)
+        .expect("expected repo root three dirs above helios-sys")
+        .to_path_buf()
+}
+
+fn ensure_archive(lib_dir: &Path) {
+    let archive = lib_dir.join("libhelios.a");
+    if archive.exists() && env::var("HELIOS_SKIP_GO_BUILD").as_deref() == Ok("1") {
+        return;
+    }
+
+    let root = repo_root();
+    let go = env::var("HELIOS_GO_BIN").unwrap_or_else(|_| "go".to_string());
+
+    // Tell cargo to rerun this build script when the Go source changes.
+    println!("cargo:rerun-if-changed={}", root.join("cmd/heliosffi/main.go").display());
+    println!("cargo:rerun-if-changed={}", root.join("pkg/helios/vst").display());
+    println!("cargo:rerun-if-env-changed=HELIOS_FFI_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=HELIOS_GO_BIN");
+    println!("cargo:rerun-if-env-changed=HELIOS_SKIP_GO_BUILD");
+
+    let status = Command::new(&go)
+        .args([
+            "build",
+            "-buildmode=c-archive",
+            "-o",
+        ])
+        .arg(&archive)
+        .arg("./cmd/heliosffi")
+        .current_dir(&root)
+        .env("CGO_ENABLED", "1")
+        .status()
+        .unwrap_or_else(|e| {
+            panic!("failed to invoke `{} build -buildmode=c-archive`: {e}", go)
+        });
+
+    if !status.success() {
+        panic!("`go build -buildmode=c-archive` failed (status={status})");
+    }
+}
+
+fn main() {
+    let lib_dir = match env::var("HELIOS_FFI_LIB_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => repo_root().join("bindings/c"),
+    };
+
+    ensure_archive(&lib_dir);
+
+    // Cargo link directives.
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=static=helios");
+    // c-archive needs pthread + dl on Linux; on macOS dl is implicit.
+    if cfg!(target_os = "linux") {
+        println!("cargo:rustc-link-lib=pthread");
+        println!("cargo:rustc-link-lib=dl");
+    } else if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-lib=framework=CoreFoundation");
+        println!("cargo:rustc-link-lib=framework=Security");
+    }
+}

--- a/bindings/rust/helios-sys/src/lib.rs
+++ b/bindings/rust/helios-sys/src/lib.rs
@@ -1,0 +1,112 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// helios-sys — raw extern declarations for libhelios.a (cmd/heliosffi).
+//
+// Handwritten rather than bindgen-generated to keep the crate dependency
+// footprint tiny (bindgen pulls libclang). The C ABI surface is small and
+// stable; see bindings/c/helios.h for the curated contract.
+
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
+use core::ffi::{c_char, c_int, c_uchar};
+
+pub type helios_vst_t = u64;
+pub type helios_fork_t = u64;
+
+/// Error codes mirrored from bindings/c/helios.h. Stable wire values.
+pub const HELIOS_OK: c_int = 0;
+pub const HELIOS_E_INVALID_ARG: c_int = -1;
+pub const HELIOS_E_INVALID_HANDLE: c_int = -2;
+pub const HELIOS_E_NOT_FOUND: c_int = -3;
+pub const HELIOS_E_INTERNAL: c_int = -4;
+pub const HELIOS_E_BRANCH_STALE: c_int = -5;
+pub const HELIOS_E_FORK_MERGED: c_int = -6;
+pub const HELIOS_E_FORK_DISCARDED: c_int = -7;
+pub const HELIOS_E_BRANCH_EXISTS: c_int = -8;
+
+extern "C" {
+    // -- VST lifecycle ----------------------------------------------------
+    pub fn helios_vst_new() -> helios_vst_t;
+    pub fn helios_vst_free(h: helios_vst_t) -> c_int;
+
+    // -- VST working set --------------------------------------------------
+    pub fn helios_vst_write_file(
+        h: helios_vst_t,
+        path: *const c_char,
+        data: *const c_uchar,
+        length: usize,
+    ) -> c_int;
+    pub fn helios_vst_read_file(
+        h: helios_vst_t,
+        path: *const c_char,
+        out_buf: *mut *mut c_uchar,
+        out_len: *mut usize,
+    ) -> c_int;
+    pub fn helios_vst_delete_file(h: helios_vst_t, path: *const c_char) -> c_int;
+
+    // -- VST commit / restore --------------------------------------------
+    pub fn helios_vst_commit(
+        h: helios_vst_t,
+        msg: *const c_char,
+        out_id: *mut *mut c_char,
+        out_len: *mut usize,
+    ) -> c_int;
+    pub fn helios_vst_restore_memory(
+        h: helios_vst_t,
+        id: *const c_char,
+        id_len: usize,
+    ) -> c_int;
+
+    // -- VST branches -----------------------------------------------------
+    pub fn helios_vst_create_branch(
+        h: helios_vst_t,
+        name: *const c_char,
+        head: *const c_char,
+        head_len: usize,
+    ) -> c_int;
+    pub fn helios_vst_branch_head(
+        h: helios_vst_t,
+        name: *const c_char,
+        out_id: *mut *mut c_char,
+        out_len: *mut usize,
+    ) -> c_int;
+
+    // -- Fork lifecycle ---------------------------------------------------
+    pub fn helios_fork_new(
+        h: helios_vst_t,
+        base: *const c_char,
+        base_len: usize,
+        out_fork: *mut helios_fork_t,
+    ) -> c_int;
+    pub fn helios_fork_discard(fh: helios_fork_t) -> c_int;
+    pub fn helios_fork_write(
+        fh: helios_fork_t,
+        path: *const c_char,
+        data: *const c_uchar,
+        length: usize,
+    ) -> c_int;
+    pub fn helios_fork_read(
+        fh: helios_fork_t,
+        path: *const c_char,
+        out_buf: *mut *mut c_uchar,
+        out_len: *mut usize,
+    ) -> c_int;
+    pub fn helios_fork_delete(fh: helios_fork_t, path: *const c_char) -> c_int;
+    pub fn helios_fork_merge_into(
+        fh: helios_fork_t,
+        branch: *const c_char,
+        out_id: *mut *mut c_char,
+        out_len: *mut usize,
+    ) -> c_int;
+
+    // -- Deallocators -----------------------------------------------------
+    pub fn helios_buffer_free(buf: *mut c_uchar);
+    pub fn helios_string_free(s: *mut c_char);
+}

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,0 +1,443 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// helios-rs — safe Rust wrapper over helios-sys (libhelios.a c-archive).
+//
+// Provides:
+//   Vst       — owning handle for a Helios VST instance.
+//   Fork      — owning handle for a copy-on-write overlay.
+//   SnapshotId, BranchId — newtype wrappers around String.
+//
+// Drop impls call the corresponding helios_*_free / helios_fork_discard,
+// so leaking a handle requires explicit `mem::forget`. All allocations
+// returned from Go (data buffers, snapshot ids) are copied into Rust-owned
+// Vec/String and then released via helios_buffer_free / helios_string_free.
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::ffi::{CString, NulError};
+use std::fmt;
+use std::ptr;
+use std::slice;
+
+use helios_sys as sys;
+use thiserror::Error;
+
+/// Errors returned by helios-rs.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid argument")]
+    InvalidArg,
+    #[error("invalid handle")]
+    InvalidHandle,
+    #[error("not found")]
+    NotFound,
+    #[error("internal helios error")]
+    Internal,
+    #[error("branch head moved since fork (stale merge)")]
+    BranchStale,
+    #[error("fork already merged")]
+    ForkMerged,
+    #[error("fork already discarded")]
+    ForkDiscarded,
+    #[error("branch already exists")]
+    BranchExists,
+    #[error("path contained interior NUL byte: {0}")]
+    Nul(#[from] NulError),
+    #[error("unknown FFI error code: {0}")]
+    Unknown(i32),
+}
+
+fn rc_to_result(rc: i32) -> Result<(), Error> {
+    match rc {
+        sys::HELIOS_OK => Ok(()),
+        sys::HELIOS_E_INVALID_ARG => Err(Error::InvalidArg),
+        sys::HELIOS_E_INVALID_HANDLE => Err(Error::InvalidHandle),
+        sys::HELIOS_E_NOT_FOUND => Err(Error::NotFound),
+        sys::HELIOS_E_INTERNAL => Err(Error::Internal),
+        sys::HELIOS_E_BRANCH_STALE => Err(Error::BranchStale),
+        sys::HELIOS_E_FORK_MERGED => Err(Error::ForkMerged),
+        sys::HELIOS_E_FORK_DISCARDED => Err(Error::ForkDiscarded),
+        sys::HELIOS_E_BRANCH_EXISTS => Err(Error::BranchExists),
+        other => Err(Error::Unknown(other)),
+    }
+}
+
+/// SnapshotId is the content-addressed handle to a committed VST state.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SnapshotId(pub String);
+
+impl fmt::Debug for SnapshotId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SnapshotId({})", self.0)
+    }
+}
+
+impl fmt::Display for SnapshotId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for SnapshotId {
+    fn from(s: String) -> Self {
+        SnapshotId(s)
+    }
+}
+
+/// BranchId names a mutable head pointer.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct BranchId(pub String);
+
+impl From<&str> for BranchId {
+    fn from(s: &str) -> Self {
+        BranchId(s.to_owned())
+    }
+}
+
+/// Owned VST handle. Drop calls helios_vst_free.
+pub struct Vst {
+    handle: sys::helios_vst_t,
+}
+
+impl Vst {
+    /// Create a new in-process VST instance.
+    pub fn new() -> Self {
+        // SAFETY: helios_vst_new has no preconditions; it always returns a
+        // valid handle id (Go side panics on OOM rather than returning 0).
+        let h = unsafe { sys::helios_vst_new() };
+        Vst { handle: h }
+    }
+
+    /// Write `data` at `path` in the working set.
+    pub fn write_file(&self, path: &str, data: &[u8]) -> Result<(), Error> {
+        let c_path = CString::new(path)?;
+        // SAFETY: handle is valid; path/data lifetimes outlive the call.
+        let rc = unsafe {
+            sys::helios_vst_write_file(
+                self.handle,
+                c_path.as_ptr(),
+                if data.is_empty() { ptr::null() } else { data.as_ptr() },
+                data.len(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Read the working-set content at `path`. Returns Ok(None) if absent.
+    pub fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>, Error> {
+        let c_path = CString::new(path)?;
+        let mut buf: *mut u8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params are owned locals.
+        let rc = unsafe {
+            sys::helios_vst_read_file(self.handle, c_path.as_ptr(), &mut buf, &mut len)
+        };
+        rc_to_result(rc)?;
+        Ok(copy_owned_buffer(buf, len))
+    }
+
+    /// Delete a path from the working set (no-op if absent).
+    pub fn delete_file(&self, path: &str) -> Result<(), Error> {
+        let c_path = CString::new(path)?;
+        // SAFETY: handle valid; path lifetime outlives the call.
+        let rc = unsafe { sys::helios_vst_delete_file(self.handle, c_path.as_ptr()) };
+        rc_to_result(rc)
+    }
+
+    /// Commit the working set and return the new SnapshotId.
+    pub fn commit(&self, msg: &str) -> Result<SnapshotId, Error> {
+        let c_msg = CString::new(msg)?;
+        let mut out: *mut i8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params owned locals.
+        let rc = unsafe {
+            sys::helios_vst_commit(self.handle, c_msg.as_ptr(), &mut out, &mut len)
+        };
+        rc_to_result(rc)?;
+        Ok(SnapshotId(copy_owned_string(out, len)))
+    }
+
+    /// Restore a committed snapshot into the working set (memory only; no
+    /// filesystem materialisation). Equivalent to `checkout` for the hot
+    /// agent loop.
+    pub fn restore(&self, id: &SnapshotId) -> Result<(), Error> {
+        let bytes = id.0.as_bytes();
+        // SAFETY: handle valid; bytes lifetime outlives the call.
+        let rc = unsafe {
+            sys::helios_vst_restore_memory(
+                self.handle,
+                bytes.as_ptr() as *const i8,
+                bytes.len(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Register a named branch pointing at `head`.
+    pub fn create_branch(&self, name: &BranchId, head: &SnapshotId) -> Result<(), Error> {
+        let c_name = CString::new(name.0.as_str())?;
+        let head_bytes = head.0.as_bytes();
+        // SAFETY: handle valid; name/head outlive the call.
+        let rc = unsafe {
+            sys::helios_vst_create_branch(
+                self.handle,
+                c_name.as_ptr(),
+                head_bytes.as_ptr() as *const i8,
+                head_bytes.len(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Return the current head SnapshotId for a branch, or None if unknown.
+    pub fn branch_head(&self, name: &BranchId) -> Result<Option<SnapshotId>, Error> {
+        let c_name = CString::new(name.0.as_str())?;
+        let mut out: *mut i8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params owned locals.
+        let rc = unsafe {
+            sys::helios_vst_branch_head(self.handle, c_name.as_ptr(), &mut out, &mut len)
+        };
+        match rc_to_result(rc) {
+            Ok(()) => Ok(Some(SnapshotId(copy_owned_string(out, len)))),
+            Err(Error::NotFound) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Open a copy-on-write Fork rooted at `base`.
+    pub fn fork(&self, base: &SnapshotId) -> Result<Fork<'_>, Error> {
+        let bytes = base.0.as_bytes();
+        let mut fh: sys::helios_fork_t = 0;
+        // SAFETY: handle valid; out param owned local.
+        let rc = unsafe {
+            sys::helios_fork_new(
+                self.handle,
+                bytes.as_ptr() as *const i8,
+                bytes.len(),
+                &mut fh,
+            )
+        };
+        rc_to_result(rc)?;
+        Ok(Fork {
+            handle: fh,
+            _vst: std::marker::PhantomData,
+        })
+    }
+
+    /// Raw FFI handle. Exposed for FFI interop with other languages; do not
+    /// call helios_vst_free on this from external code while the Vst exists.
+    pub fn raw_handle(&self) -> sys::helios_vst_t {
+        self.handle
+    }
+}
+
+impl Default for Vst {
+    fn default() -> Self {
+        Vst::new()
+    }
+}
+
+impl Drop for Vst {
+    fn drop(&mut self) {
+        // SAFETY: handle is owned by this struct; double-free guarded by Go side
+        // (LoadAndDelete on the registry).
+        unsafe {
+            let _ = sys::helios_vst_free(self.handle);
+        }
+    }
+}
+
+// SAFETY: All Vst ops go through the goroutine-safe Go runtime via uint64
+// handle dispatch. There is no thread-local state on the Rust side.
+unsafe impl Send for Vst {}
+unsafe impl Sync for Vst {}
+
+/// Owned Fork handle. Lifetime-bound to the parent Vst so the registry cannot
+/// be torn down underneath an active fork. Drop calls helios_fork_discard.
+pub struct Fork<'v> {
+    handle: sys::helios_fork_t,
+    _vst: std::marker::PhantomData<&'v Vst>,
+}
+
+impl<'v> Fork<'v> {
+    /// Write `data` at `path` in the fork overlay (RAM only).
+    pub fn write(&self, path: &str, data: &[u8]) -> Result<(), Error> {
+        let c_path = CString::new(path)?;
+        // SAFETY: handle valid; path/data outlive the call.
+        let rc = unsafe {
+            sys::helios_fork_write(
+                self.handle,
+                c_path.as_ptr(),
+                if data.is_empty() { ptr::null() } else { data.as_ptr() },
+                data.len(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Read `path` through the overlay (overlay → tombstone → base).
+    pub fn read(&self, path: &str) -> Result<Option<Vec<u8>>, Error> {
+        let c_path = CString::new(path)?;
+        let mut buf: *mut u8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params owned locals.
+        let rc = unsafe {
+            sys::helios_fork_read(self.handle, c_path.as_ptr(), &mut buf, &mut len)
+        };
+        rc_to_result(rc)?;
+        Ok(copy_owned_buffer(buf, len))
+    }
+
+    /// Tombstone a path in the fork (no-op if absent from base).
+    pub fn delete(&self, path: &str) -> Result<(), Error> {
+        let c_path = CString::new(path)?;
+        // SAFETY: handle valid; path outlives the call.
+        let rc = unsafe { sys::helios_fork_delete(self.handle, c_path.as_ptr()) };
+        rc_to_result(rc)
+    }
+
+    /// Atomically merge this fork into `branch`. Consumes the fork on success
+    /// (the handle is invalidated). On `Error::BranchStale` the fork remains
+    /// alive and the caller may rebase and retry.
+    pub fn merge_into(mut self, branch: &BranchId) -> Result<SnapshotId, (Self, Error)> {
+        let c_branch = match CString::new(branch.0.as_str()) {
+            Ok(s) => s,
+            Err(e) => return Err((self, Error::Nul(e))),
+        };
+        let mut out: *mut i8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params owned locals.
+        let rc = unsafe {
+            sys::helios_fork_merge_into(self.handle, c_branch.as_ptr(), &mut out, &mut len)
+        };
+        match rc_to_result(rc) {
+            Ok(()) => {
+                let id = SnapshotId(copy_owned_string(out, len));
+                // Go side already invalidated the handle on success; suppress
+                // Drop's discard to avoid the redundant InvalidHandle return.
+                self.handle = 0;
+                Ok(id)
+            }
+            Err(e) => Err((self, e)),
+        }
+    }
+
+    /// Explicit discard. Drop calls this automatically; prefer Drop unless
+    /// you want to release fork RAM before scope end.
+    pub fn discard(mut self) {
+        if self.handle != 0 {
+            // SAFETY: handle valid; idempotent on Go side.
+            unsafe { let _ = sys::helios_fork_discard(self.handle); }
+            self.handle = 0;
+        }
+    }
+
+    /// Raw FFI handle (do not pass to helios_fork_discard externally).
+    pub fn raw_handle(&self) -> sys::helios_fork_t {
+        self.handle
+    }
+}
+
+impl<'v> Drop for Fork<'v> {
+    fn drop(&mut self) {
+        if self.handle != 0 {
+            // SAFETY: handle valid; Go side ignores already-discarded forks.
+            unsafe { let _ = sys::helios_fork_discard(self.handle); }
+        }
+    }
+}
+
+// SAFETY: same goroutine-safe rationale as Vst; the handle is uint64.
+unsafe impl<'v> Send for Fork<'v> {}
+unsafe impl<'v> Sync for Fork<'v> {}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn copy_owned_buffer(buf: *mut u8, len: usize) -> Option<Vec<u8>> {
+    if buf.is_null() {
+        // Treat NULL as "not present" for read paths (matches VST.ReadFile
+        // semantics where missing → (nil, nil)).
+        return None;
+    }
+    // SAFETY: Go-side guarantees buf was malloc'd with `len` valid bytes.
+    let bytes = unsafe { slice::from_raw_parts(buf, len) };
+    let owned = bytes.to_vec();
+    // SAFETY: buf was allocated by C.malloc on the Go side.
+    unsafe { sys::helios_buffer_free(buf); }
+    Some(owned)
+}
+
+fn copy_owned_string(ptr: *mut i8, len: usize) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    // SAFETY: Go-side guarantees NUL terminator at offset `len`.
+    let bytes = unsafe { slice::from_raw_parts(ptr as *const u8, len) };
+    let owned = String::from_utf8_lossy(bytes).into_owned();
+    // SAFETY: ptr was allocated by C.malloc on the Go side.
+    unsafe { sys::helios_string_free(ptr); }
+    owned
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn end_to_end_fork_merge() {
+        let v = Vst::new();
+        v.write_file("a.txt", b"alpha").unwrap();
+        let base = v.commit("seed").unwrap();
+        let branch: BranchId = "main".into();
+        v.create_branch(&branch, &base).unwrap();
+
+        let f = v.fork(&base).unwrap();
+        f.write("a.txt", b"alpha-2").unwrap();
+        let got = f.read("a.txt").unwrap().unwrap();
+        assert_eq!(got, b"alpha-2");
+        let new_id = f.merge_into(&branch).map_err(|(_, e)| e).unwrap();
+
+        let head = v.branch_head(&branch).unwrap().unwrap();
+        assert_eq!(head, new_id);
+        assert_ne!(head, base);
+    }
+
+    #[test]
+    fn stale_cas_returns_branch_stale() {
+        let v = Vst::new();
+        v.write_file("a.txt", b"alpha").unwrap();
+        let base = v.commit("seed").unwrap();
+        let branch: BranchId = "main".into();
+        v.create_branch(&branch, &base).unwrap();
+
+        let fa = v.fork(&base).unwrap();
+        let fb = v.fork(&base).unwrap();
+
+        fa.write("a.txt", b"A").unwrap();
+        fb.write("a.txt", b"B").unwrap();
+
+        let _ = fa.merge_into(&branch).map_err(|(_, e)| e).unwrap();
+
+        // Project the error code only; drop the Fork before v goes out of scope.
+        let stale_code = match fb.merge_into(&branch) {
+            Ok(_) => None,
+            Err((fb_alive, e)) => {
+                drop(fb_alive);
+                Some(e)
+            }
+        };
+        match stale_code {
+            Some(Error::BranchStale) => (),
+            other => panic!("expected BranchStale, got {other:?}"),
+        }
+    }
+}

--- a/cmd/heliosffi/main.go
+++ b/cmd/heliosffi/main.go
@@ -1,0 +1,447 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main produces a CGO c-archive (libhelios.a + libhelios.h) exporting
+// a minimal, opaque-handle C ABI for the Helios VST + VFSFork primitives.
+// Intended for in-process consumers (Rust via bindgen, Python via ctypes,
+// any C-FFI capable runtime) that cannot afford a subprocess-per-op model.
+//
+// Build:
+//   go build -buildmode=c-archive -o bindings/c/libhelios.a ./cmd/heliosffi
+//
+// All returned heap buffers (data, snapshot ids, error messages) are allocated
+// with C.malloc and MUST be released by the caller with helios_buffer_free
+// (for byte buffers) or helios_string_free (for NUL-terminated strings).
+//
+// Handles (helios_vst_t, helios_fork_t) are opaque uint64 ids backed by a
+// process-global sync.Map. They are NOT pointers; passing a freed handle is
+// safe and returns HELIOS_E_INVALID_HANDLE.
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+*/
+import "C"
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/good-night-oppie/helios/pkg/helios/types"
+	"github.com/good-night-oppie/helios/pkg/helios/vst"
+)
+
+// Error codes mirrored on the C side via helios.h preamble.
+// Stable wire values; do not reorder.
+const (
+	cOK              C.int = 0
+	cErrInvalidArg   C.int = -1
+	cErrInvalidHdl   C.int = -2
+	cErrNotFound     C.int = -3
+	cErrInternal     C.int = -4
+	cErrBranchStale  C.int = -5
+	cErrForkMerged   C.int = -6
+	cErrForkDiscard  C.int = -7
+	cErrBranchExists C.int = -8
+)
+
+// Handle registry: process-wide opaque uint64 → *VST or *Fork.
+// Separate maps keep type-confusion impossible.
+var (
+	vstReg     sync.Map // uint64 -> *vst.VST
+	forkReg    sync.Map // uint64 -> *vst.Fork
+	vstNextID  uint64
+	forkNextID uint64
+)
+
+func registerVST(v *vst.VST) uint64 {
+	id := atomic.AddUint64(&vstNextID, 1)
+	vstReg.Store(id, v)
+	return id
+}
+
+func lookupVST(id uint64) *vst.VST {
+	val, ok := vstReg.Load(id)
+	if !ok {
+		return nil
+	}
+	return val.(*vst.VST)
+}
+
+func registerFork(f *vst.Fork) uint64 {
+	id := atomic.AddUint64(&forkNextID, 1)
+	forkReg.Store(id, f)
+	return id
+}
+
+func lookupFork(id uint64) *vst.Fork {
+	val, ok := forkReg.Load(id)
+	if !ok {
+		return nil
+	}
+	return val.(*vst.Fork)
+}
+
+// cBufFromBytes copies a Go slice into a C.malloc'd buffer and writes its
+// pointer + length through the supplied out params. Returns cOK on success.
+// The caller must helios_buffer_free the returned pointer.
+func cBufFromBytes(data []byte, outBuf **C.uchar, outLen *C.size_t) C.int {
+	if outBuf == nil || outLen == nil {
+		return cErrInvalidArg
+	}
+	if len(data) == 0 {
+		*outBuf = nil
+		*outLen = 0
+		return cOK
+	}
+	p := C.malloc(C.size_t(len(data)))
+	if p == nil {
+		return cErrInternal
+	}
+	C.memcpy(p, unsafe.Pointer(&data[0]), C.size_t(len(data)))
+	*outBuf = (*C.uchar)(p)
+	*outLen = C.size_t(len(data))
+	return cOK
+}
+
+// cStrFromString copies a Go string into a NUL-terminated C.malloc'd buffer.
+// On success writes pointer to *outStr and length (without NUL) to *outLen.
+func cStrFromString(s string, outStr **C.char, outLen *C.size_t) C.int {
+	if outStr == nil {
+		return cErrInvalidArg
+	}
+	p := C.malloc(C.size_t(len(s) + 1))
+	if p == nil {
+		return cErrInternal
+	}
+	if len(s) > 0 {
+		C.memcpy(p, unsafe.Pointer(unsafe.StringData(s)), C.size_t(len(s)))
+	}
+	// trailing NUL
+	*(*byte)(unsafe.Pointer(uintptr(p) + uintptr(len(s)))) = 0
+	*outStr = (*C.char)(p)
+	if outLen != nil {
+		*outLen = C.size_t(len(s))
+	}
+	return cOK
+}
+
+// goBytesFromC creates a Go slice view (no copy) over a C-owned buffer.
+func goBytesFromC(buf *C.uchar, n C.size_t) []byte {
+	if n == 0 || buf == nil {
+		return nil
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(buf)), int(n))
+}
+
+// goStringFromC reads a NUL-terminated C string into a Go string.
+func goStringFromC(s *C.char) string {
+	if s == nil {
+		return ""
+	}
+	return C.GoString(s)
+}
+
+// goStringFromCN reads a (ptr, len) C string into a Go string (no NUL needed).
+func goStringFromCN(s *C.char, n C.size_t) string {
+	if s == nil || n == 0 {
+		return ""
+	}
+	return C.GoStringN(s, C.int(n))
+}
+
+// ---------------------------------------------------------------------------
+// VST lifecycle
+// ---------------------------------------------------------------------------
+
+//export helios_vst_new
+func helios_vst_new() C.uint64_t {
+	v := vst.New()
+	return C.uint64_t(registerVST(v))
+}
+
+//export helios_vst_free
+func helios_vst_free(h C.uint64_t) C.int {
+	id := uint64(h)
+	val, ok := vstReg.LoadAndDelete(id)
+	if !ok {
+		return cErrInvalidHdl
+	}
+	v := val.(*vst.VST)
+	_ = v.Close()
+	return cOK
+}
+
+// ---------------------------------------------------------------------------
+// VST: working-set IO
+// ---------------------------------------------------------------------------
+
+//export helios_vst_write_file
+func helios_vst_write_file(h C.uint64_t, path *C.char, data *C.uchar, length C.size_t) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	if path == nil {
+		return cErrInvalidArg
+	}
+	// Copy the C bytes into a Go-owned slice (VST.WriteFile already copies but
+	// this keeps the contract explicit and avoids retaining the C pointer).
+	src := goBytesFromC(data, length)
+	cp := make([]byte, len(src))
+	copy(cp, src)
+	if err := v.WriteFile(goStringFromC(path), cp); err != nil {
+		return cErrInternal
+	}
+	return cOK
+}
+
+//export helios_vst_read_file
+func helios_vst_read_file(h C.uint64_t, path *C.char, outBuf **C.uchar, outLen *C.size_t) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	if path == nil {
+		return cErrInvalidArg
+	}
+	b, err := v.ReadFile(goStringFromC(path))
+	if err != nil {
+		return cErrInternal
+	}
+	return cBufFromBytes(b, outBuf, outLen)
+}
+
+//export helios_vst_delete_file
+func helios_vst_delete_file(h C.uint64_t, path *C.char) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	if path == nil {
+		return cErrInvalidArg
+	}
+	v.DeleteFile(goStringFromC(path))
+	return cOK
+}
+
+// ---------------------------------------------------------------------------
+// VST: commit / restore
+// ---------------------------------------------------------------------------
+
+//export helios_vst_commit
+func helios_vst_commit(h C.uint64_t, msg *C.char, outID **C.char, outLen *C.size_t) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	id, _, err := v.Commit(goStringFromC(msg))
+	if err != nil {
+		return cErrInternal
+	}
+	return cStrFromString(string(id), outID, outLen)
+}
+
+//export helios_vst_restore_memory
+func helios_vst_restore_memory(h C.uint64_t, id *C.char, idLen C.size_t) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	sid := types.SnapshotID(goStringFromCN(id, idLen))
+	// In-memory restore only: bypass filesystem materialisation so the FFI
+	// path is suitable for hot agent loops (no PWD coupling, no atomic-rename).
+	if err := v.RestoreWithOpts(sid, types.RestoreOpts{DryRun: false, WriteToFilesystem: false}); err != nil {
+		return cErrNotFound
+	}
+	return cOK
+}
+
+// ---------------------------------------------------------------------------
+// VST: branches
+// ---------------------------------------------------------------------------
+
+//export helios_vst_create_branch
+func helios_vst_create_branch(h C.uint64_t, name *C.char, head *C.char, headLen C.size_t) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	if name == nil {
+		return cErrInvalidArg
+	}
+	err := v.CreateBranch(vst.BranchID(goStringFromC(name)), types.SnapshotID(goStringFromCN(head, headLen)))
+	switch err {
+	case nil:
+		return cOK
+	case vst.ErrBranchExists:
+		return cErrBranchExists
+	default:
+		return cErrInternal
+	}
+}
+
+//export helios_vst_branch_head
+func helios_vst_branch_head(h C.uint64_t, name *C.char, outID **C.char, outLen *C.size_t) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	id, ok := v.BranchHead(vst.BranchID(goStringFromC(name)))
+	if !ok {
+		return cErrNotFound
+	}
+	return cStrFromString(string(id), outID, outLen)
+}
+
+// ---------------------------------------------------------------------------
+// Fork lifecycle
+// ---------------------------------------------------------------------------
+
+//export helios_fork_new
+func helios_fork_new(h C.uint64_t, base *C.char, baseLen C.size_t, outForkHdl *C.uint64_t) C.int {
+	v := lookupVST(uint64(h))
+	if v == nil {
+		return cErrInvalidHdl
+	}
+	if outForkHdl == nil {
+		return cErrInvalidArg
+	}
+	f, err := v.Fork(types.SnapshotID(goStringFromCN(base, baseLen)))
+	if err != nil {
+		return cErrNotFound
+	}
+	*outForkHdl = C.uint64_t(registerFork(f))
+	return cOK
+}
+
+//export helios_fork_discard
+func helios_fork_discard(fh C.uint64_t) C.int {
+	id := uint64(fh)
+	val, ok := forkReg.LoadAndDelete(id)
+	if !ok {
+		return cErrInvalidHdl
+	}
+	f := val.(*vst.Fork)
+	f.Discard()
+	return cOK
+}
+
+//export helios_fork_write
+func helios_fork_write(fh C.uint64_t, path *C.char, data *C.uchar, length C.size_t) C.int {
+	f := lookupFork(uint64(fh))
+	if f == nil {
+		return cErrInvalidHdl
+	}
+	if path == nil {
+		return cErrInvalidArg
+	}
+	src := goBytesFromC(data, length)
+	if err := f.Write(goStringFromC(path), src); err != nil {
+		return forkErrToCode(err)
+	}
+	return cOK
+}
+
+//export helios_fork_read
+func helios_fork_read(fh C.uint64_t, path *C.char, outBuf **C.uchar, outLen *C.size_t) C.int {
+	f := lookupFork(uint64(fh))
+	if f == nil {
+		return cErrInvalidHdl
+	}
+	if path == nil {
+		return cErrInvalidArg
+	}
+	b, err := f.Read(goStringFromC(path))
+	if err != nil {
+		return forkErrToCode(err)
+	}
+	return cBufFromBytes(b, outBuf, outLen)
+}
+
+//export helios_fork_delete
+func helios_fork_delete(fh C.uint64_t, path *C.char) C.int {
+	f := lookupFork(uint64(fh))
+	if f == nil {
+		return cErrInvalidHdl
+	}
+	if path == nil {
+		return cErrInvalidArg
+	}
+	if err := f.Delete(goStringFromC(path)); err != nil {
+		return forkErrToCode(err)
+	}
+	return cOK
+}
+
+//export helios_fork_merge_into
+func helios_fork_merge_into(fh C.uint64_t, branch *C.char, outID **C.char, outLen *C.size_t) C.int {
+	f := lookupFork(uint64(fh))
+	if f == nil {
+		return cErrInvalidHdl
+	}
+	if branch == nil {
+		return cErrInvalidArg
+	}
+	id, err := f.MergeInto(vst.BranchID(goStringFromC(branch)))
+	if err != nil {
+		return forkErrToCode(err)
+	}
+	// On successful merge the fork is consumed: drop its handle so callers can't
+	// reuse it (Discard is a no-op on merged forks, but freeing the slot keeps
+	// the registry from leaking).
+	forkReg.Delete(uint64(fh))
+	return cStrFromString(string(id), outID, outLen)
+}
+
+func forkErrToCode(err error) C.int {
+	switch err {
+	case nil:
+		return cOK
+	case vst.ErrBranchStale:
+		return cErrBranchStale
+	case vst.ErrForkMerged:
+		return cErrForkMerged
+	case vst.ErrForkDiscarded:
+		return cErrForkDiscard
+	case vst.ErrUnknownBranch, vst.ErrUnknownSnapshot:
+		return cErrNotFound
+	default:
+		return cErrInternal
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Buffer / string deallocators
+// ---------------------------------------------------------------------------
+
+//export helios_buffer_free
+func helios_buffer_free(buf *C.uchar) {
+	if buf != nil {
+		C.free(unsafe.Pointer(buf))
+	}
+}
+
+//export helios_string_free
+func helios_string_free(s *C.char) {
+	if s != nil {
+		C.free(unsafe.Pointer(s))
+	}
+}
+
+// main is required by Go but never executed for buildmode=c-archive.
+func main() {}

--- a/docs/ionq-integration.md
+++ b/docs/ionq-integration.md
@@ -1,0 +1,176 @@
+# Helios ↔ ionq integration (Vectors A/B)
+
+This document is the reference for embedding Helios in multi-agent runtimes
+that cannot afford a subprocess per checkpoint/checkout cycle. It covers the
+two P0 primitives ionq consumes:
+
+- **Vector A — checkpoint backend.** In-process VST `Commit`/`Restore`
+  exposed via CGO `c-archive` (`cmd/heliosffi`) and a safe Rust wrapper
+  (`bindings/rust/helios-rs`).
+- **Vector B — in-memory validation harness.** `VFSFork` overlay primitive
+  (`pkg/helios/vst/fork.go`) — fork-without-commit, validate-against-fork,
+  atomic compare-and-swap merge or discard. Memory cost is O(changed chunks),
+  not O(working set).
+
+The K-way speculative scheduler (Vector C) is deferred to P1.
+
+---
+
+## Architecture at a glance
+
+```
++----------------------------------------------------------------+
+| ionq Rust runtime  (or any C-FFI capable language)             |
++----------------------------------------------------------------+
+              | helios_rs (safe wrapper, lifetimes + thiserror)
+              v
++----------------------------------------------------------------+
+| helios-sys: extern "C" decls (handwritten, bindgen-free)       |
++----------------------------------------------------------------+
+              | C ABI (uint64 opaque handles)
+              v
++----------------------------------------------------------------+
+| libhelios.a  ←  go build -buildmode=c-archive ./cmd/heliosffi  |
+|   cmd/heliosffi   →  pkg/helios/vst   (VST + Fork + branches)  |
+|                       BLAKE3 CAS + Merkle tree                 |
++----------------------------------------------------------------+
+```
+
+The FFI surface is intentionally narrow. All cross-language allocations are
+owned by the side that allocated them: Go-allocated buffers ship back via
+`helios_buffer_free`/`helios_string_free`; Rust-allocated slices stay on
+the Rust stack.
+
+---
+
+## Build & smoke test
+
+```bash
+# 1. Build libhelios.a + libhelios.h via cgo c-archive
+make ffi-archive
+
+# 2. Compile and run the C smoke test
+make ffi-smoke
+
+# 3. Build the Rust crate workspace (helios-sys + helios-rs)
+make rust-build
+
+# 4. Run the round-trip example (init→commit→fork→merge→restore)
+make rust-smoke
+```
+
+Reference timings (Intel Xeon 8259CL, release build, single-threaded, warm):
+
+| Op                              | Wall  | Notes                          |
+|---------------------------------|-------|--------------------------------|
+| `Vst::new` (warm)               |  ~2 µs | cold first call ~6 ms (Go runtime init, amortised) |
+| `write_file`                    | ~15 µs |                                |
+| `commit` (1 file)               | ~80 µs |                                |
+| `create_branch`                 |  ~2 µs |                                |
+| `fork`                          |  ~3 µs |                                |
+| `fork.write` (overlay)          |  ~2 µs |                                |
+| `fork.read` (base passthrough)  |  ~2 µs |                                |
+| `fork.merge_into` (success CAS) | ~17 µs | excludes RocksDB flush         |
+| `fork.merge_into` (stale CAS)   |  ~7 µs | branch head moved; fork alive  |
+| `branch_head`                   |  ~2 µs |                                |
+| `restore` (in-memory)           |  ~3 µs |                                |
+
+All values comfortably under the 1 ms / 50 µs / 100 µs gates from the brief.
+
+---
+
+## C ABI: error codes
+
+All entry points return `int`; `0` = success, negative = error. Defined in
+`bindings/c/helios.h` and `bindings/rust/helios-sys/src/lib.rs`:
+
+| Constant                       | Value | Meaning                                     |
+|--------------------------------|------:|---------------------------------------------|
+| `HELIOS_OK`                    |   0   | success                                     |
+| `HELIOS_E_INVALID_ARG`         |  -1   | NULL pointer or empty required arg          |
+| `HELIOS_E_INVALID_HANDLE`      |  -2   | handle is unknown or already freed          |
+| `HELIOS_E_NOT_FOUND`           |  -3   | snapshot / branch / path not found          |
+| `HELIOS_E_INTERNAL`            |  -4   | unexpected Go-side error (check stderr)     |
+| `HELIOS_E_BRANCH_STALE`        |  -5   | merge CAS failed; branch head moved         |
+| `HELIOS_E_FORK_MERGED`         |  -6   | op attempted on already-merged fork         |
+| `HELIOS_E_FORK_DISCARDED`      |  -7   | op attempted on already-discarded fork      |
+| `HELIOS_E_BRANCH_EXISTS`       |  -8   | `CreateBranch` collision                    |
+
+Wire values are **stable**; do not reorder.
+
+---
+
+## Ownership & threading contract
+
+- **Handles** (`helios_vst_t`, `helios_fork_t`) are opaque `uint64` values
+  backed by a process-global `sync.Map`. They are NOT pointers. `0` is
+  reserved as "no handle" only in `helios_fork_new`'s out-param.
+- **Output byte buffers** (`unsigned char **out_buf`) are allocated via
+  `C.malloc` on the Go side and MUST be released with `helios_buffer_free`.
+- **Output strings** (`char **out_id`) are NUL-terminated and released
+  with `helios_string_free`. The length out-param does NOT include the NUL.
+- **Concurrency:** the library is goroutine-safe AND thread-safe. Distinct
+  forks may be driven from distinct OS threads in parallel. The Rust wrapper
+  marks `Vst` / `Fork` as `Send + Sync` accordingly.
+
+---
+
+## VFSFork semantics (Vector B core)
+
+The Fork primitive sits between "ephemeral working set" and "committed
+snapshot": it is a copy-on-write overlay over an immutable base snapshot.
+
+```
+                              fork.MergeInto(branch)
+   base SnapshotID --+--> Fork --+--> new SnapshotID  (branch head advances)
+                     |           |
+                     |           +--> ErrBranchStale  (branch head moved)
+                     |                (fork stays alive; caller may rebase)
+                     |
+                     +--> Fork --+--> Discard          (RAM released, no I/O)
+```
+
+Constraints honoured by the implementation:
+
+1. **No RocksDB writes until MergeInto succeeds.** Fork overlays live in L0
+   (per-fork RAM map). Blobs and snapshot metadata are only persisted to L2
+   inside the successful `MergeInto` phase 4.
+2. **Atomic compare-and-swap on the branch head.** If `f.base != branches[branch]`
+   at the moment the VST write lock is acquired, `ErrBranchStale` is returned
+   and no state is mutated.
+3. **`Discard` is mandatory.** A `runtime.SetFinalizer` is wired defensively
+   so dropped Forks do not pin memory forever, but the explicit `Discard`
+   path is the supported lifecycle. The Rust `Fork::drop` calls
+   `helios_fork_discard` automatically.
+4. **Parallel fork safety.** K forks from the same base share an immutable
+   reference to the base snapshot map. Tests cover both disjoint-branch
+   parallelism (32 forks × 100 ops) and racing-CAS parallelism (16 forks
+   competing for the same branch with rebase-retry; exactly K winners).
+
+---
+
+## Where things live
+
+| Path                                     | Purpose                                   |
+|------------------------------------------|-------------------------------------------|
+| `pkg/helios/vst/fork.go`                 | Fork type + MergeInto/Discard/Diff/Read/Write |
+| `pkg/helios/vst/branch.go`               | Branch registry (CreateBranch/BranchHead/...) |
+| `pkg/helios/vst/fork_test.go`            | Functional + concurrent + finalizer tests |
+| `pkg/helios/vst/fork_bench_test.go`      | Microbenchmarks for the acceptance gates  |
+| `cmd/heliosffi/main.go`                  | CGO `//export` shim — opaque uint64 ABI   |
+| `bindings/c/helios.h`                    | Curated C header (error codes + contract) |
+| `bindings/c/smoke.c`                     | C-level round-trip smoke test             |
+| `bindings/rust/helios-sys/`              | Raw `extern "C"` declarations + build.rs  |
+| `bindings/rust/src/lib.rs`               | Safe wrapper: `Vst`, `Fork`, `SnapshotId` |
+| `bindings/rust/examples/helios_smoke.rs` | `cargo run --example helios_smoke`        |
+
+---
+
+## Out of scope for P0 (deferred)
+
+- **FastCDC chunking** (Vector A enhancement; file-level CAS is fine for now).
+- **`Validator` trait + `propose_and_select`** (Vector C, P1+).
+- **Two-tier hash** (BLAKE3-only stays).
+- **WAL fsync chaos-test** (P2 reliability).
+- **Replay-deterministic event journal link** (P2).
+- **Fork TTL via generation marker** (P2 GC).


### PR DESCRIPTION
## Summary (PR 2/2 in stack — depends on #38)

Add in-process FFI surface bringing `VST` + `VFSFork` into the same process as a Rust runtime. Removes the ~10ms subprocess fork-exec overhead per checkpoint, which collapses the 8ms checkpoint demo budget for multi-agent runtimes like ionq (**Vector A** in the integration memo).

## Stack

- **Base:** #38 `feat(fork): VFSFork overlay primitive`
- **This:** `feat/ionq-vector-a-ffi`
- **Merge order:** #38 first, then this

## Layout

| Path | Role |
|---|---|
| `cmd/heliosffi/main.go` | CGO `//export` shim, opaque `uint64` handle ABI, `sync.Map` registry, `C.malloc`-backed output buffers |
| `bindings/c/helios.h` | Curated C header — error codes + contract |
| `bindings/c/smoke.c` | End-to-end C round-trip smoke |
| `bindings/rust/helios-sys/` | Raw `extern \"C\"` decls (bindgen-free, handwritten) |
| `bindings/rust/src/lib.rs` | Safe wrapper: `Vst`, `Fork<'v>`, `SnapshotId`, `BranchId`, `Drop`-on-discard, `Send + Sync`, lifetime-bound forks |
| `bindings/rust/examples/helios_smoke.rs` | `cargo run --example helios_smoke` round-trip + CAS rebase |

Makefile targets: `ffi-archive`, `ffi-smoke`, `rust-build`, `rust-test`, `rust-smoke`.

`build.rs` invokes `go build -buildmode=c-archive` automatically — Rust consumers do not need a separate Go build step.

## Acceptance

| Item | Target | Actual |
|---|---:|---:|
| `cargo run --example helios_smoke` init→write→commit→checkout | < 1ms/op | every op 2–80µs (warm) |
| `go test ./pkg/... ./internal/... ./cmd/helios-cli/internal/...` | green | green |
| Existing Go API breakage | none | additions only |
| README quick-start updated with Rust example | required | yes (`## Integration` subsection) |

## Smoke output (warm, Intel Xeon 8259CL, release)

```
  OK   init (Vst::new, warm)            1.95 us
  OK   write seed                      15.02 us
  OK   commit                          82.60 us
  OK   create_branch(main)              1.73 us
  OK   fork                             3.02 us
  OK   fork.merge_into(main)           17.26 us
  OK   restore (in-memory)              3.02 us

CAS rebase loop:
  OK   f1.merge_into                   14.43 us
  OK   f2.merge_into (stale)            6.51 us  ← ErrBranchStale
  OK   f2.merge_into (retry)           18.82 us
```

Cold-start note: first `Vst::new` in a process pays ~5ms for Go runtime init (one-time, amortised). Smoke harness wires a warmup so measured init is steady-state ~2µs.

## Test plan

- [x] `make ffi-smoke` (C round-trip)
- [x] `make rust-smoke` (`cargo run --example helios_smoke`)
- [x] `cargo test -p helios-rs`
- [ ] Reviewer: validate CGO opaque-handle ABI stability across `c-archive` rebuilds
- [ ] Reviewer: validate Rust `Fork<'v>` lifetime can't escape its `Vst`

## Drive-by fixes (prereq for `go test ./... green`)

- `cmd/helios-cli/internal/cli/cli_test.go` — `FakeEngine` missing `Close()` after `Engine` interface gained it; added no-op `Close()`

## Pre-existing master breakage (left untouched, documented for separate triage)

- `cmd/helios-cli/TestCLI_CommitAndStats_Smoke` — Pebble emits WAL recovery log to stderr which test parses as JSON
- `tests/integration/TestRestore_PromotesFromL2ToL1` — L1 cache stats stay zero after restore
- `stress/TestConcurrentMCTS`, `stress/TestTimeTravelChess` — wall-clock gates under `-race` on shared-CPU sandbox

None affect FFI surface or Fork correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)