### PR TITLE
fix: PR #38/#39 review follow-ups (TOCTOU race + FFI empty-file)

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -363,10 +363,21 @@ unsafe impl<'v> Sync for Fork<'v> {}
 // ---------------------------------------------------------------------------
 
 fn copy_owned_buffer(buf: *mut u8, len: usize) -> Option<Vec<u8>> {
+    // Three-way encoding from cBufFromBytes in cmd/heliosffi/main.go:
+    //   NULL                  -> None       (path absent)
+    //   non-NULL,  len == 0   -> Some(vec![]) (path present, zero bytes)
+    //   non-NULL,  len > 0    -> Some(bytes)
     if buf.is_null() {
-        // Treat NULL as "not present" for read paths (matches VST.ReadFile
-        // semantics where missing → (nil, nil)).
         return None;
+    }
+    if len == 0 {
+        // Empty-but-present sentinel: Go allocated a 1-byte placeholder so
+        // we can distinguish absence from emptiness. We must NOT read it
+        // (its contents are uninitialised) but we still own it and must
+        // hand it back to helios_buffer_free.
+        // SAFETY: buf was allocated by C.malloc on the Go side.
+        unsafe { sys::helios_buffer_free(buf); }
+        return Some(Vec::new());
     }
     // SAFETY: Go-side guarantees buf was malloc'd with `len` valid bytes.
     let bytes = unsafe { slice::from_raw_parts(buf, len) };
@@ -391,6 +402,46 @@ fn copy_owned_string(ptr: *mut i8, len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // PR #39 review follow-up: write b"" then read back must yield
+    // Some(vec![]) — NOT None. None means "absent"; an existing empty
+    // file is a distinct state. Before the fix, cBufFromBytes returned
+    // NULL for both nil and []byte{}, collapsing the two states on the
+    // Rust side.
+    #[test]
+    fn test_empty_file_roundtrip_vst() {
+        let v = Vst::new();
+        v.write_file("empty.txt", b"").unwrap();
+        let got = v.read_file("empty.txt").unwrap();
+        assert_eq!(got, Some(Vec::new()), "VST: empty file must be Some(vec![]) not None");
+
+        // Absent file must still read back as None.
+        let missing = v.read_file("does_not_exist.txt").unwrap();
+        assert_eq!(missing, None, "VST: absent file must read back as None");
+
+        // Round-trip survives commit → fork → read.
+        let base = v.commit("seed").unwrap();
+        let branch: BranchId = "main".into();
+        v.create_branch(&branch, &base).unwrap();
+
+        let f = v.fork(&base).unwrap();
+        let from_fork_base = f.read("empty.txt").unwrap();
+        assert_eq!(
+            from_fork_base,
+            Some(Vec::new()),
+            "Fork base passthrough: empty file must be Some(vec![]) not None"
+        );
+
+        // Fork-overlay empty write also round-trips.
+        f.write("overlay_empty.txt", b"").unwrap();
+        let from_overlay = f.read("overlay_empty.txt").unwrap();
+        assert_eq!(
+            from_overlay,
+            Some(Vec::new()),
+            "Fork overlay: empty file must be Some(vec![]) not None"
+        );
+        f.discard();
+    }
 
     #[test]
     fn end_to_end_fork_merge() {

--- a/cmd/heliosffi/main.go
+++ b/cmd/heliosffi/main.go
@@ -98,13 +98,41 @@ func lookupFork(id uint64) *vst.Fork {
 
 // cBufFromBytes copies a Go slice into a C.malloc'd buffer and writes its
 // pointer + length through the supplied out params. Returns cOK on success.
-// The caller must helios_buffer_free the returned pointer.
+// The caller must helios_buffer_free the returned pointer (safe to call on
+// NULL — Go side helios_buffer_free no-ops on nil).
+//
+// Three-way encoding so callers can distinguish "missing" from "present
+// but empty":
+//
+//	data == nil               → (*outBuf = NULL,        *outLen = 0)
+//	                            interpreted as "path does not exist"
+//	data != nil, len(data)==0 → (*outBuf = malloc(1),   *outLen = 0)
+//	                            interpreted as "path exists, zero bytes"
+//	len(data) > 0             → (*outBuf = malloc(len), *outLen = len)
+//
+// The empty-but-present case allocates a 1-byte placeholder so that a
+// caller checking `out_buf != NULL` correctly sees an existing empty file
+// rather than mistaking it for absence. The reported length is still 0 so
+// no reader will dereference the placeholder; helios_buffer_free reclaims
+// the byte. See PR #39 review for the round-trip failure this fixes.
 func cBufFromBytes(data []byte, outBuf **C.uchar, outLen *C.size_t) C.int {
 	if outBuf == nil || outLen == nil {
 		return cErrInvalidArg
 	}
-	if len(data) == 0 {
+	if data == nil {
+		// Absent path: NULL + 0 = "not found".
 		*outBuf = nil
+		*outLen = 0
+		return cOK
+	}
+	if len(data) == 0 {
+		// Present empty path: distinguish from nil by allocating a single
+		// byte placeholder. Length stays 0; consumers must not read it.
+		p := C.malloc(1)
+		if p == nil {
+			return cErrInternal
+		}
+		*outBuf = (*C.uchar)(p)
 		*outLen = 0
 		return cOK
 	}

--- a/pkg/helios/vst/fork.go
+++ b/pkg/helios/vst/fork.go
@@ -163,10 +163,14 @@ func (f *Fork) ensureOpen() error {
 
 // Write installs content at path in the fork overlay.
 // Content is hashed (BLAKE3) and held in fork-local RAM; no RocksDB I/O.
+//
+// The hash compute is done outside the lock (pure CPU, no shared state) but
+// the ensureOpen() state check happens inside the lock to close the TOCTOU
+// race with a concurrent Discard: if Discard wins the state CAS after our
+// check but before our Lock, Discard would nil the overlay/content maps
+// underneath us. With the check held under the same lock Discard later
+// acquires, that ordering can no longer produce a nil-map panic.
 func (f *Fork) Write(path string, content []byte) error {
-	if err := f.ensureOpen(); err != nil {
-		return err
-	}
 	cp := make([]byte, len(content))
 	copy(cp, content)
 	h, err := util.HashBlob(cp)
@@ -174,52 +178,57 @@ func (f *Fork) Write(path string, content []byte) error {
 		return err
 	}
 	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.ensureOpen(); err != nil {
+		return err
+	}
 	f.overlay[path] = h
 	delete(f.tombstones, path)
 	f.content[string(h.Digest)] = cp
-	f.mu.Unlock()
 	return nil
 }
 
 // Delete tombstones a path in the fork. Read will return nil for that path
 // even if it exists in base. The tombstone is honoured at MergeInto time.
+// ensureOpen() is held inside the lock; see Write for the TOCTOU rationale.
 func (f *Fork) Delete(path string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if err := f.ensureOpen(); err != nil {
 		return err
 	}
-	f.mu.Lock()
 	delete(f.overlay, path)
 	f.tombstones[path] = struct{}{}
-	f.mu.Unlock()
 	return nil
 }
 
 // Read returns the content of path as visible through the fork:
 // overlay → tombstone (nil) → base. Returns (nil, nil) if path is absent.
 // The returned slice is a copy and may be modified by the caller.
+//
+// The RLock excludes Discard's write Lock, so a concurrent Discard cannot
+// nil the maps mid-read. ensureOpen() is checked inside the RLock to close
+// the TOCTOU window between an outside-the-lock check and lock acquisition.
 func (f *Fork) Read(path string) ([]byte, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if err := f.ensureOpen(); err != nil {
 		return nil, err
 	}
-	f.mu.RLock()
 	if _, deleted := f.tombstones[path]; deleted {
-		f.mu.RUnlock()
 		return nil, nil
 	}
 	if h, ok := f.overlay[path]; ok {
 		if c, ok2 := f.content[string(h.Digest)]; ok2 {
 			cp := make([]byte, len(c))
 			copy(cp, c)
-			f.mu.RUnlock()
 			return cp, nil
 		}
 	}
-	base := f.baseSnap
-	f.mu.RUnlock()
-	if base == nil {
+	if f.baseSnap == nil {
 		return nil, nil
 	}
-	if v, ok := base[path]; ok {
+	if v, ok := f.baseSnap[path]; ok {
 		cp := make([]byte, len(v))
 		copy(cp, v)
 		return cp, nil
@@ -229,12 +238,13 @@ func (f *Fork) Read(path string) ([]byte, error) {
 
 // Diff returns the set of path-level changes between the fork and its base,
 // sorted by path for deterministic output. Safe to call concurrently.
+// ensureOpen() is checked inside the RLock; see Read for the rationale.
 func (f *Fork) Diff() []Change {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if err := f.ensureOpen(); err != nil {
 		return nil
 	}
-	f.mu.RLock()
-	defer f.mu.RUnlock()
 
 	changes := make([]Change, 0, len(f.overlay)+len(f.tombstones))
 	for path, h := range f.overlay {
@@ -299,13 +309,16 @@ func (f *Fork) Discard() {
 // On success the new snapshot is materialised into VST (and L2 if attached),
 // the branch head is advanced, and the fork is transitioned to merged state.
 func (f *Fork) MergeInto(branch BranchID) (types.SnapshotID, error) {
-	if err := f.ensureOpen(); err != nil {
-		return "", err
-	}
 	v := f.vst
 
 	// --- Phase 1: snapshot fork state under read lock (no VST lock yet) ---
+	// ensureOpen() is checked inside the RLock so a concurrent Discard cannot
+	// nil baseSnap/overlay/content/tombstones between the check and the read.
 	f.mu.RLock()
+	if err := f.ensureOpen(); err != nil {
+		f.mu.RUnlock()
+		return "", err
+	}
 	composed := make(map[string][]byte, len(f.baseSnap)+len(f.overlay))
 	for k, val := range f.baseSnap {
 		composed[k] = val // share immutable base bytes; we deep-copy at store time

--- a/pkg/helios/vst/fork_test.go
+++ b/pkg/helios/vst/fork_test.go
@@ -418,3 +418,130 @@ func hasPrefix(s, p string) bool {
 	}
 	return true
 }
+
+// TestFork_DiscardRaceTOCTOU stresses the TOCTOU window between an
+// out-of-lock state check and lock acquisition in Fork.Write / Read /
+// Delete / Diff / MergeInto. Before the fix, a concurrent Discard could
+// CAS state→discarded and nil the internal maps between a method's
+// ensureOpen() check and its f.mu lock, causing a nil-map write panic.
+//
+// Strategy: spawn many goroutines that hammer mutating ops while a single
+// goroutine races to Discard the fork. Run -race so any unsynchronised
+// map read/write would fire the race detector. The only acceptable per-op
+// outcomes are: success, or ErrForkDiscarded. No panics, no data races.
+//
+// Run with: go test -v -run TestFork_DiscardRaceTOCTOU -race -count=10 ./...
+func TestFork_DiscardRaceTOCTOU(t *testing.T) {
+	const iters = 1000
+
+	for i := 0; i < iters; i++ {
+		v, branch, _ := setupBase(t, map[string]string{"seed.txt": "seed"})
+		base := v.mustHead(t, branch)
+		f, err := v.Fork(base)
+		if err != nil {
+			t.Fatalf("iter %d: Fork: %v", i, err)
+		}
+
+		const writers = 4
+		var wg sync.WaitGroup
+		wg.Add(writers + 1)
+
+		// Writers hammer all the mutating + read paths concurrently.
+		for w := 0; w < writers; w++ {
+			go func(wid int) {
+				defer wg.Done()
+				path := fmt.Sprintf("w%d.txt", wid)
+				payload := []byte(fmt.Sprintf("payload-%d", wid))
+				for j := 0; j < 32; j++ {
+					if err := f.Write(path, payload); err != nil && !errors.Is(err, ErrForkDiscarded) {
+						t.Errorf("iter %d writer %d Write: unexpected err %v", i, wid, err)
+						return
+					}
+					if _, err := f.Read(path); err != nil && !errors.Is(err, ErrForkDiscarded) {
+						t.Errorf("iter %d writer %d Read: unexpected err %v", i, wid, err)
+						return
+					}
+					if err := f.Delete(path); err != nil && !errors.Is(err, ErrForkDiscarded) {
+						t.Errorf("iter %d writer %d Delete: unexpected err %v", i, wid, err)
+						return
+					}
+					// Diff returns nil on discarded fork (not an error path) so
+					// just exercising it is enough to catch nil-map panics.
+					_ = f.Diff()
+				}
+			}(w)
+		}
+
+		// Single discarder racing the writers.
+		go func() {
+			defer wg.Done()
+			// Slight stagger so the first iterations of each writer have a
+			// chance to interleave with the state CAS.
+			runtime.Gosched()
+			f.Discard()
+		}()
+
+		wg.Wait()
+
+		// After Discard, every op must terminate cleanly.
+		if err := f.Write("post.txt", []byte("x")); !errors.Is(err, ErrForkDiscarded) {
+			t.Fatalf("iter %d: post-discard Write err = %v; want ErrForkDiscarded", i, err)
+		}
+		if _, err := f.Read("post.txt"); !errors.Is(err, ErrForkDiscarded) {
+			t.Fatalf("iter %d: post-discard Read err = %v; want ErrForkDiscarded", i, err)
+		}
+	}
+}
+
+// TestFork_MergeIntoVsDiscardRace exercises the analogous TOCTOU between
+// MergeInto's phase-1 read snapshot and a concurrent Discard. Acceptable
+// outcomes: (a) merge wins, branch advances; (b) discard wins, MergeInto
+// returns ErrForkDiscarded with no branch advance. No panics, no races.
+func TestFork_MergeIntoVsDiscardRace(t *testing.T) {
+	const iters = 200
+
+	for i := 0; i < iters; i++ {
+		v, branch, _ := setupBase(t, map[string]string{"seed.txt": "seed"})
+		base := v.mustHead(t, branch)
+		f, err := v.Fork(base)
+		if err != nil {
+			t.Fatalf("iter %d: Fork: %v", i, err)
+		}
+		// Plant a few overlay writes so MergeInto has real phase-1 work.
+		for k := 0; k < 4; k++ {
+			path := fmt.Sprintf("k%d.txt", k)
+			if err := f.Write(path, []byte("v")); err != nil {
+				t.Fatalf("iter %d: Write: %v", i, err)
+			}
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		var mergeErr error
+		go func() {
+			defer wg.Done()
+			_, mergeErr = f.MergeInto(branch)
+		}()
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			f.Discard()
+		}()
+		wg.Wait()
+
+		head, _ := v.BranchHead(branch)
+		switch {
+		case mergeErr == nil:
+			if head == base {
+				t.Fatalf("iter %d: merge ok but head did not advance", i)
+			}
+		case errors.Is(mergeErr, ErrForkDiscarded):
+			// Acceptable: Discard CAS'd state before phase-1 ensureOpen check.
+			if head != base {
+				t.Fatalf("iter %d: discard-wins case but branch advanced (head=%s)", i, head)
+			}
+		default:
+			t.Fatalf("iter %d: unexpected MergeInto err: %v", i, mergeErr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two review follow-ups on already-merged PRs:

- **PR #38 review (commit 3a550b5)** — close TOCTOU race in `Fork.Write` / `Read` / `Delete` / `Diff` / `MergeInto` where `ensureOpen()` was checked outside `f.mu`, letting a concurrent `Discard` nil the internal maps mid-call and panic the caller.
- **PR #39 review (commit 0fd3e0e)** — `cBufFromBytes` returned `(NULL, 0)` for both `nil` and `[]byte{}`, so the Rust wrapper could not distinguish an absent file from an existing empty file. Writing `b\"\"` then reading it back yielded `Ok(None)` instead of `Ok(Some(vec![]))`.

Lineage: refs PR #38, refs PR #39 (both already merged to master).

## Commits

| SHA | Subject |
|-----|---------|
| `5263ac1` | fix(fork): close TOCTOU race in Fork.* methods (PR #38 review follow-up) |
| `091e6bc` | fix(ffi): distinguish nil vs empty []byte in cBufFromBytes (PR #39 review follow-up) |

## TOCTOU fix details (PR #38)

Discard's contract is:

1. \`atomic.CAS(state, open, discarded)\`
2. \`f.mu.Lock()\` — wait for any in-flight method
3. nil \`overlay\` / \`tombstones\` / \`content\` / \`baseSnap\`
4. \`f.mu.Unlock()\`

Before the fix, \`Fork.Write\` was:

1. \`ensureOpen()\` — state == open, ok
2. (Discard wedges in fully: CAS + Lock + nil + Unlock)
3. \`f.mu.Lock()\`
4. \`f.overlay[path] = h\` ← **PANIC: assignment to entry in nil map**

Fix: move the \`ensureOpen()\` check into the same \`f.mu\` critical section that touches the maps. Pure-CPU work (BLAKE3 hashing in \`Write\`) stays outside the lock; only the state check + map mutations are guarded. Discard's CAS now races with the lock, not with an unsynchronised state check.

## FFI empty-file fix details (PR #39)

Three-way encoding on the Go side, mirrored in the Rust side:

| Go input | C wire | Rust output |
|----------|--------|-------------|
| \`data == nil\` | \`(NULL, 0)\` | \`Ok(None)\` |
| \`data != nil && len(data) == 0\` | \`(malloc(1), 0)\` | \`Ok(Some(vec![]))\` |
| \`len(data) > 0\` | \`(malloc(len), len)\` | \`Ok(Some(bytes))\` |

The empty-but-present case allocates a single-byte placeholder so a caller checking \`buf.is_null()\` correctly sees an existing empty file. The reported length stays \`0\` so no reader will dereference the placeholder; the byte is reclaimed by \`helios_buffer_free\` (already nil-safe).

## Test plan

- [x] \`go test -v -run TestFork -race -count=10 ./pkg/helios/vst/...\` — all green, including 1000-iter \`TestFork_DiscardRaceTOCTOU\` and 200-iter \`TestFork_MergeIntoVsDiscardRace\`.
- [x] \`make ffi-archive && cd bindings/rust && cargo test --release\` — 3 tests green, including new \`test_empty_file_roundtrip_vst\`.
- [x] \`go test -race ./pkg/... ./internal/... ./cmd/helios-cli/internal/...\` — full core race suite green.
- [ ] **Operator review only** — do not merge without sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)