### PR TITLE
feat(vst): AgentId thread-through (Go-side, PR-VA-1a)

### DIFF
--- a/pkg/helios/vst/agent.go
+++ b/pkg/helios/vst/agent.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vst
+
+import (
+	"github.com/good-night-oppie/helios/pkg/helios/types"
+)
+
+// AgentId names a tenant in the VST namespace. Multi-tenant callers thread
+// AgentId through *ForAgent methods; single-tenant callers use the existing
+// methods which delegate to AgentDefault. AgentId values must be valid UTF-8
+// strings; the empty string is normalised to AgentDefault.
+type AgentId string
+
+// AgentDefault is the reserved agent used by the legacy single-tenant API.
+// All non-agent-qualified methods (WriteFile, CreateBranch, Fork, ...) act
+// on this agent so existing callers keep working unchanged.
+const AgentDefault AgentId = "default"
+
+// normaliseAgent maps the empty string to AgentDefault. Callers should
+// always pass the result of this through to per-agent state lookups.
+func normaliseAgent(a AgentId) AgentId {
+	if a == "" {
+		return AgentDefault
+	}
+	return a
+}
+
+// agentState carries the per-tenant slice of VST state. Snapshots remain
+// content-addressed and shared across agents in VST.snaps so that the same
+// content from any agent dedups to a single entry.
+type agentState struct {
+	cur        map[string][]byte             // current working set
+	pathToHash map[string]types.Hash         // working-set path -> blob hash (for L1/L2 fetch)
+	branches   map[BranchID]types.SnapshotID // named branch heads
+}
+
+func newAgentState() *agentState {
+	return &agentState{
+		cur:        make(map[string][]byte),
+		pathToHash: make(map[string]types.Hash),
+		branches:   make(map[BranchID]types.SnapshotID),
+	}
+}
+
+// agentRO returns the agent's state for read-only access. The caller must
+// hold at least v.mu.RLock. Returns (nil, false) if the agent has never
+// been written to (single-tenant readers should fall through to the
+// L1/L2-via-snap path; multi-tenant callers should treat absence as
+// NotFound).
+func (v *VST) agentRO(a AgentId) (*agentState, bool) {
+	s, ok := v.agents[normaliseAgent(a)]
+	return s, ok
+}
+
+// agentRW returns the agent's state for read-write access, lazily creating
+// it if absent. The caller MUST hold v.mu.Lock (write lock); calling under
+// only RLock will race with concurrent agentRW from another goroutine.
+func (v *VST) agentRW(a AgentId) *agentState {
+	a = normaliseAgent(a)
+	if s, ok := v.agents[a]; ok {
+		return s
+	}
+	s := newAgentState()
+	v.agents[a] = s
+	return s
+}

--- a/pkg/helios/vst/agent.go
+++ b/pkg/helios/vst/agent.go
@@ -15,6 +15,9 @@
 package vst
 
 import (
+	"errors"
+	"unicode/utf8"
+
 	"github.com/good-night-oppie/helios/pkg/helios/types"
 )
 
@@ -28,6 +31,21 @@ type AgentId string
 // All non-agent-qualified methods (WriteFile, CreateBranch, Fork, ...) act
 // on this agent so existing callers keep working unchanged.
 const AgentDefault AgentId = "default"
+
+// ErrInvalidAgent is returned by error-returning *ForAgent methods when the
+// supplied AgentId is not valid UTF-8. Void / boolean methods treat invalid
+// IDs as a silent miss (no-op delete, not-found read).
+var ErrInvalidAgent = errors.New("vst: AgentId must be valid UTF-8")
+
+// validateAgent enforces the AgentId UTF-8 contract documented on AgentId.
+// The empty string is allowed at this layer because normaliseAgent maps it
+// to AgentDefault.
+func validateAgent(a AgentId) error {
+	if !utf8.ValidString(string(a)) {
+		return ErrInvalidAgent
+	}
+	return nil
+}
 
 // normaliseAgent maps the empty string to AgentDefault. Callers should
 // always pass the result of this through to per-agent state lookups.

--- a/pkg/helios/vst/agent_test.go
+++ b/pkg/helios/vst/agent_test.go
@@ -1,0 +1,278 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package vst
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestVST_AgentPathIsolation: two agents writing the same path must read
+// back their own content. Cross-agent reads of unwritten paths return
+// (nil, nil).
+func TestVST_AgentPathIsolation(t *testing.T) {
+	v := New()
+	const a, b AgentId = "alpha", "beta"
+
+	if err := v.WriteFileForAgent(a, "x.txt", []byte("A")); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+	if err := v.WriteFileForAgent(b, "x.txt", []byte("B")); err != nil {
+		t.Fatalf("write beta: %v", err)
+	}
+
+	got, err := v.ReadFileForAgent(a, "x.txt")
+	if err != nil || string(got) != "A" {
+		t.Fatalf("alpha read: got=%q err=%v want=A", got, err)
+	}
+	got, err = v.ReadFileForAgent(b, "x.txt")
+	if err != nil || string(got) != "B" {
+		t.Fatalf("beta read: got=%q err=%v want=B", got, err)
+	}
+
+	// Cross-agent read of a path written only by the other agent: NotFound.
+	got, err = v.ReadFileForAgent("gamma", "x.txt")
+	if err != nil || got != nil {
+		t.Fatalf("gamma read of unwritten path: got=%q err=%v want=nil,nil", got, err)
+	}
+}
+
+// TestVST_DefaultAgentPassthrough: the legacy single-tenant API resolves
+// to AgentDefault. WriteFile then ReadFileForAgent(AgentDefault, ...) sees
+// the value; symmetric direction also works.
+func TestVST_DefaultAgentPassthrough(t *testing.T) {
+	v := New()
+	if err := v.WriteFile("p", []byte("v")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := v.ReadFile("p")
+	if err != nil || string(got) != "v" {
+		t.Fatalf("ReadFile: got=%q err=%v want=v", got, err)
+	}
+	got, err = v.ReadFileForAgent(AgentDefault, "p")
+	if err != nil || string(got) != "v" {
+		t.Fatalf("ReadFileForAgent(default): got=%q err=%v want=v", got, err)
+	}
+	if err := v.WriteFileForAgent(AgentDefault, "p", []byte("v2")); err != nil {
+		t.Fatalf("WriteFileForAgent(default): %v", err)
+	}
+	got, err = v.ReadFile("p")
+	if err != nil || string(got) != "v2" {
+		t.Fatalf("ReadFile after for-agent overwrite: got=%q err=%v want=v2", got, err)
+	}
+
+	// Empty-string agent normalises to AgentDefault.
+	got, err = v.ReadFileForAgent("", "p")
+	if err != nil || string(got) != "v2" {
+		t.Fatalf("ReadFileForAgent(\"\"): got=%q err=%v want=v2", got, err)
+	}
+}
+
+// TestVST_AgentBranchIsolation: two agents may register the same branch
+// name pointing at different snapshots; lookups never cross agents.
+func TestVST_AgentBranchIsolation(t *testing.T) {
+	v := New()
+	const a, b AgentId = "alpha", "beta"
+
+	// Commit a snapshot under each agent so we have valid heads.
+	if err := v.WriteFileForAgent(a, "x", []byte("a1")); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	sa, _, err := v.CommitForAgent(a, "alpha-1")
+	if err != nil {
+		t.Fatalf("commit a: %v", err)
+	}
+	if err := v.WriteFileForAgent(b, "x", []byte("b1")); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	sb, _, err := v.CommitForAgent(b, "beta-1")
+	if err != nil {
+		t.Fatalf("commit b: %v", err)
+	}
+
+	if err := v.CreateBranchForAgent(a, "main", sa); err != nil {
+		t.Fatalf("create branch a: %v", err)
+	}
+	if err := v.CreateBranchForAgent(b, "main", sb); err != nil {
+		t.Fatalf("create branch b: %v", err)
+	}
+
+	gotA, okA := v.BranchHeadForAgent(a, "main")
+	if !okA || gotA != sa {
+		t.Fatalf("alpha/main: got=%s ok=%v want=%s", gotA, okA, sa)
+	}
+	gotB, okB := v.BranchHeadForAgent(b, "main")
+	if !okB || gotB != sb {
+		t.Fatalf("beta/main: got=%s ok=%v want=%s", gotB, okB, sb)
+	}
+	if gotA == gotB {
+		t.Fatalf("expected distinct branch heads across agents; both=%s", gotA)
+	}
+
+	// Default-agent has no branch named "main"; not visible.
+	if _, ok := v.BranchHead("main"); ok {
+		t.Fatalf("default agent unexpectedly sees branch main")
+	}
+
+	// DeleteBranchForAgent removes only the targeted agent's entry.
+	if err := v.DeleteBranchForAgent(a, "main"); err != nil {
+		t.Fatalf("delete alpha/main: %v", err)
+	}
+	if _, ok := v.BranchHeadForAgent(a, "main"); ok {
+		t.Fatalf("alpha/main still present after delete")
+	}
+	if _, ok := v.BranchHeadForAgent(b, "main"); !ok {
+		t.Fatalf("beta/main vanished after deleting alpha/main")
+	}
+}
+
+// TestFork_AgentScopedMergeInto: a fork opened under agent_a only advances
+// branches under agent_a. Identically-named branches under agent_b are
+// untouched.
+func TestFork_AgentScopedMergeInto(t *testing.T) {
+	v := New()
+	const a, b AgentId = "alpha", "beta"
+
+	// Seed: each agent commits and registers main pointing at its own snapshot.
+	if err := v.WriteFileForAgent(a, "x", []byte("a0")); err != nil {
+		t.Fatal(err)
+	}
+	sa0, _, err := v.CommitForAgent(a, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := v.WriteFileForAgent(b, "x", []byte("b0")); err != nil {
+		t.Fatal(err)
+	}
+	sb0, _, err := v.CommitForAgent(b, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := v.CreateBranchForAgent(a, "main", sa0); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.CreateBranchForAgent(b, "main", sb0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open a fork under alpha, mutate, merge into alpha/main.
+	fa, err := v.ForkForAgent(a, sa0)
+	if err != nil {
+		t.Fatalf("fork a: %v", err)
+	}
+	if fa.Agent() != a {
+		t.Fatalf("fork.Agent: got=%s want=%s", fa.Agent(), a)
+	}
+	if err := fa.Write("x", []byte("a1")); err != nil {
+		t.Fatal(err)
+	}
+	sa1, err := fa.MergeInto("main")
+	if err != nil {
+		t.Fatalf("merge alpha: %v", err)
+	}
+	if sa1 == sa0 {
+		t.Fatalf("alpha/main did not advance: still %s", sa0)
+	}
+	if got, _ := v.BranchHeadForAgent(a, "main"); got != sa1 {
+		t.Fatalf("alpha/main head: got=%s want=%s", got, sa1)
+	}
+	// beta/main untouched.
+	if got, _ := v.BranchHeadForAgent(b, "main"); got != sb0 {
+		t.Fatalf("beta/main moved: got=%s want=%s", got, sb0)
+	}
+
+	// Merging an alpha-scoped fork into a branch that exists only under beta
+	// must return ErrUnknownBranch (the fork can't reach beta's namespace).
+	if err := v.DeleteBranchForAgent(a, "main"); err != nil {
+		t.Fatal(err)
+	}
+	fa2, err := v.ForkForAgent(a, sa1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fa2.MergeInto("main"); !errors.Is(err, ErrUnknownBranch) {
+		t.Fatalf("merge into unknown branch: got=%v want=ErrUnknownBranch", err)
+	}
+	fa2.Discard()
+}
+
+// TestVST_AgentCommitSharedSnapshot: identical content from different
+// agents produces the same SnapshotID. The snapshot is content-addressed
+// globally; the per-agent dimension is on working state, not the snap store.
+func TestVST_AgentCommitSharedSnapshot(t *testing.T) {
+	v := New()
+	const a, b AgentId = "alpha", "beta"
+	payload := []byte("hello")
+
+	if err := v.WriteFileForAgent(a, "p", payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.WriteFileForAgent(b, "p", payload); err != nil {
+		t.Fatal(err)
+	}
+
+	sa, _, err := v.CommitForAgent(a, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb, _, err := v.CommitForAgent(b, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sa != sb {
+		t.Fatalf("expected same SnapshotID for identical content; alpha=%s beta=%s", sa, sb)
+	}
+}
+
+// TestVST_ConcurrentAgentsWrites: K goroutines each writing N paths under
+// a distinct agent. Under -race, no data race must fire and each agent's
+// final state must contain its full N paths.
+func TestVST_ConcurrentAgentsWrites(t *testing.T) {
+	const (
+		K = 8
+		N = 200
+	)
+	v := New()
+
+	var wg sync.WaitGroup
+	wg.Add(K)
+	for k := 0; k < K; k++ {
+		go func(k int) {
+			defer wg.Done()
+			agent := AgentId(fmt.Sprintf("a%d", k))
+			for i := 0; i < N; i++ {
+				path := fmt.Sprintf("p%d", i)
+				val := fmt.Sprintf("a%d-v%d", k, i)
+				if err := v.WriteFileForAgent(agent, path, []byte(val)); err != nil {
+					t.Errorf("write k=%d i=%d: %v", k, i, err)
+					return
+				}
+			}
+		}(k)
+	}
+	wg.Wait()
+
+	// Verify each agent sees its own N paths with correct content.
+	for k := 0; k < K; k++ {
+		agent := AgentId(fmt.Sprintf("a%d", k))
+		for i := 0; i < N; i++ {
+			path := fmt.Sprintf("p%d", i)
+			want := fmt.Sprintf("a%d-v%d", k, i)
+			got, err := v.ReadFileForAgent(agent, path)
+			if err != nil {
+				t.Fatalf("read k=%d i=%d: %v", k, i, err)
+			}
+			if string(got) != want {
+				t.Fatalf("read k=%d i=%d: got=%q want=%q", k, i, got, want)
+			}
+		}
+	}
+}

--- a/pkg/helios/vst/agent_test.go
+++ b/pkg/helios/vst/agent_test.go
@@ -437,3 +437,64 @@ func TestVST_RestoreForAgent_Isolation(t *testing.T) {
 		t.Fatalf("beta post-alpha-restore: got=%q want=b-original (cross-tenant leak)", gotB)
 	}
 }
+
+// TestVST_DeleteFileForAgent_ClearsPathToHash pins working-set delete
+// semantics. Pre-fix, DeleteFileForAgent removed only s.cur[path] but
+// left s.pathToHash[path] intact. After a Commit, cur is COW-swapped
+// empty but pathToHash retains every committed path; a subsequent
+// Delete-then-Read would still resolve via the pathToHash fallback
+// (L1/L2 lookup in production wiring), so a "deleted" file could be
+// silently resurrected from cache/store.
+//
+// White-box: directly inspect s.pathToHash. This is enough to pin the
+// invariant without dragging in pebble/objstore wiring for an L1/L2
+// end-to-end round-trip.
+func TestVST_DeleteFileForAgent_ClearsPathToHash(t *testing.T) {
+	v := New()
+	const a AgentId = "delete-agent"
+	const p = "doomed.txt"
+
+	if err := v.WriteFileForAgent(a, p, []byte("payload")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := v.CommitForAgent(a, ""); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// After Commit, cur is empty but pathToHash holds the path -> hash entry.
+	v.mu.RLock()
+	s, ok := v.agentRO(a)
+	if !ok {
+		v.mu.RUnlock()
+		t.Fatal("agent state missing post-commit")
+	}
+	if _, hasHash := s.pathToHash[p]; !hasHash {
+		v.mu.RUnlock()
+		t.Fatal("pathToHash missing entry post-commit (commit did not register path)")
+	}
+	v.mu.RUnlock()
+
+	v.DeleteFileForAgent(a, p)
+
+	// Both maps must be free of p after Delete; otherwise ReadFileForAgent
+	// would fall through to pathToHash and return the L1/L2-resident value.
+	v.mu.RLock()
+	if _, stillInCur := s.cur[p]; stillInCur {
+		t.Errorf("DeleteFileForAgent: cur[%q] not cleared", p)
+	}
+	if _, stillInPath := s.pathToHash[p]; stillInPath {
+		t.Errorf("DeleteFileForAgent: pathToHash[%q] not cleared — deleted file would resurrect via L1/L2 fallback", p)
+	}
+	v.mu.RUnlock()
+
+	// Externally observable: with no L1/L2 attached, Read returns nil
+	// either way; this gives a defensive end-to-end check that the
+	// fast path also reports the file as absent.
+	got, err := v.ReadFileForAgent(a, p)
+	if err != nil {
+		t.Fatalf("post-delete read: %v", err)
+	}
+	if got != nil {
+		t.Errorf("post-delete read: got=%q want=nil", got)
+	}
+}

--- a/pkg/helios/vst/agent_test.go
+++ b/pkg/helios/vst/agent_test.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+
+	"github.com/good-night-oppie/helios/pkg/helios/types"
 )
 
 // TestVST_AgentPathIsolation: two agents writing the same path must read
@@ -274,5 +276,105 @@ func TestVST_ConcurrentAgentsWrites(t *testing.T) {
 				t.Fatalf("read k=%d i=%d: got=%q want=%q", k, i, got, want)
 			}
 		}
+	}
+}
+
+// TestVST_CommitOptimizedForAgent_ConcurrentRace fires K goroutines that
+// concurrently Write + CommitOptimizedForAgent + Write under distinct
+// AgentIds. Pre-fix, the unlocked agentRW + s.cur swap + v.snaps write
+// would race the agents-map insert from another goroutine and either
+// panic ("fatal: concurrent map writes") or corrupt state. Under -race
+// this exercise must run cleanly and each agent's post-commit
+// working-set state must be empty (COW swap installed a fresh empty
+// map) until the next round of writes populates it again.
+func TestVST_CommitOptimizedForAgent_ConcurrentRace(t *testing.T) {
+	const (
+		K      = 8
+		Rounds = 50
+	)
+	v := New()
+
+	var wg sync.WaitGroup
+	wg.Add(K)
+	for k := 0; k < K; k++ {
+		go func(k int) {
+			defer wg.Done()
+			agent := AgentId(fmt.Sprintf("commit-agent-%d", k))
+			for r := 0; r < Rounds; r++ {
+				path := fmt.Sprintf("r%d.txt", r)
+				if err := v.WriteFileForAgent(agent, path, []byte(fmt.Sprintf("k%d-r%d", k, r))); err != nil {
+					t.Errorf("write k=%d r=%d: %v", k, r, err)
+					return
+				}
+				if _, _, err := v.CommitOptimizedForAgent(agent, ""); err != nil {
+					t.Errorf("commit-optimized k=%d r=%d: %v", k, r, err)
+					return
+				}
+			}
+		}(k)
+	}
+	wg.Wait()
+
+	// After Rounds rounds, every agent should have a committed snapshot
+	// installed in v.snaps. We can't easily inspect snaps here without
+	// exposing internals, so just verify that reads of the latest-written
+	// path return either the latest value (race: write→read with no commit
+	// in between) or nil (COW swap removed all entries post-commit).
+	for k := 0; k < K; k++ {
+		agent := AgentId(fmt.Sprintf("commit-agent-%d", k))
+		got, err := v.ReadFileForAgent(agent, "r0.txt")
+		if err != nil {
+			t.Fatalf("post-loop read agent=%s: %v", agent, err)
+		}
+		_ = got // value depends on COW timing; we only assert no error / no race
+	}
+}
+
+// TestVST_RestoreForAgent_Isolation: restoring a snapshot into agent_a
+// must not perturb agent_b's working state. Cross-tenant isolation
+// invariant.
+func TestVST_RestoreForAgent_Isolation(t *testing.T) {
+	v := New()
+	const a, b AgentId = "alpha", "beta"
+
+	// Seed both agents with distinct content.
+	if err := v.WriteFileForAgent(a, "p", []byte("a-original")); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.WriteFileForAgent(b, "p", []byte("b-original")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit + over-write alpha so its cur diverges from the committed snap.
+	saSeed, _, err := v.CommitForAgent(a, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := v.WriteFileForAgent(a, "p", []byte("a-mutated")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore alpha back to its seeded snapshot. Restore writes to
+	// filesystem by default, so use DryRun=true to scope this to memory.
+	if err := v.RestoreForAgent(a, saSeed, types.RestoreOpts{DryRun: true}); err != nil {
+		t.Fatalf("restore alpha: %v", err)
+	}
+
+	// Alpha's read returns the restored content.
+	gotA, err := v.ReadFileForAgent(a, "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotA) != "a-original" {
+		t.Fatalf("alpha post-restore: got=%q want=a-original", gotA)
+	}
+
+	// Beta's working set is untouched.
+	gotB, err := v.ReadFileForAgent(b, "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotB) != "b-original" {
+		t.Fatalf("beta post-alpha-restore: got=%q want=b-original (cross-tenant leak)", gotB)
 	}
 }

--- a/pkg/helios/vst/agent_test.go
+++ b/pkg/helios/vst/agent_test.go
@@ -315,18 +315,77 @@ func TestVST_CommitOptimizedForAgent_ConcurrentRace(t *testing.T) {
 	}
 	wg.Wait()
 
-	// After Rounds rounds, every agent should have a committed snapshot
-	// installed in v.snaps. We can't easily inspect snaps here without
-	// exposing internals, so just verify that reads of the latest-written
-	// path return either the latest value (race: write→read with no commit
-	// in between) or nil (COW swap removed all entries post-commit).
+	// Every goroutine's inner loop is Write -> Commit (no trailing Write),
+	// so the final post-loop state for each agent must have a freshly
+	// COW-swapped empty cur. With L1/L2 unattached, ReadFileForAgent
+	// falls through pathToHash and returns (nil, nil). Asserting that
+	// got is nil for the last-written path is the externally observable
+	// signal that the COW swap actually happened on the final Commit;
+	// pre-fix, the racy commit could leave cur unchanged and ReadFile
+	// would return the last-written value, silently regressing the
+	// concurrency fix without this assertion.
 	for k := 0; k < K; k++ {
 		agent := AgentId(fmt.Sprintf("commit-agent-%d", k))
-		got, err := v.ReadFileForAgent(agent, "r0.txt")
+		lastPath := fmt.Sprintf("r%d.txt", Rounds-1)
+		got, err := v.ReadFileForAgent(agent, lastPath)
 		if err != nil {
-			t.Fatalf("post-loop read agent=%s: %v", agent, err)
+			t.Fatalf("post-loop read agent=%s path=%s: %v", agent, lastPath, err)
 		}
-		_ = got // value depends on COW timing; we only assert no error / no race
+		if got != nil {
+			t.Errorf("post-loop read agent=%s path=%s: expected nil (cur swapped empty by final Commit, no L1/L2 attached), got=%q",
+				agent, lastPath, got)
+		}
+	}
+}
+
+// TestVST_ForAgent_RejectsInvalidUTF8 pins the AgentId contract from agent.go:
+// error-returning *ForAgent methods must surface ErrInvalidAgent for non-UTF-8
+// IDs; void / bool methods must silently no-op so a corrupt ID never reaches
+// the internal v.agents map (which would otherwise pollute iteration and
+// serialization downstream).
+func TestVST_ForAgent_RejectsInvalidUTF8(t *testing.T) {
+	v := New()
+	bad := AgentId("\xff\xfe-not-utf8")
+
+	if err := v.WriteFileForAgent(bad, "p", []byte("x")); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("WriteFileForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+	if _, err := v.ReadFileForAgent(bad, "p"); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("ReadFileForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+	if _, _, err := v.CommitForAgent(bad, ""); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("CommitForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+	if _, _, err := v.CommitOptimizedForAgent(bad, ""); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("CommitOptimizedForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+	if err := v.RestoreForAgent(bad, types.SnapshotID(""), types.RestoreOpts{DryRun: true}); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("RestoreForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+	if _, err := v.ForkForAgent(bad, types.SnapshotID("")); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("ForkForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+	if err := v.CreateBranchForAgent(bad, "b", types.SnapshotID("")); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("CreateBranchForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+	if err := v.DeleteBranchForAgent(bad, "b"); !errors.Is(err, ErrInvalidAgent) {
+		t.Errorf("DeleteBranchForAgent: got err=%v, want ErrInvalidAgent", err)
+	}
+
+	// Void / bool methods silently no-op; key invariant is that the invalid
+	// ID never lands in v.agents (would corrupt iteration / serialisation).
+	v.DeleteFileForAgent(bad, "p")
+	if _, ok := v.BranchHeadForAgent(bad, "b"); ok {
+		t.Errorf("BranchHeadForAgent: invalid agent returned ok=true")
+	}
+	if m := v.BranchesForAgent(bad); len(m) != 0 {
+		t.Errorf("BranchesForAgent: invalid agent returned %d branches, want 0", len(m))
+	}
+	v.mu.RLock()
+	_, polluted := v.agents[bad]
+	v.mu.RUnlock()
+	if polluted {
+		t.Errorf("v.agents leaked invalid AgentId %q despite validation gate", bad)
 	}
 }
 

--- a/pkg/helios/vst/branch.go
+++ b/pkg/helios/vst/branch.go
@@ -86,7 +86,17 @@ func (v *VST) Branches() map[BranchID]types.SnapshotID {
 
 // BranchesForAgent returns a snapshot of the named agent's branch map.
 // The returned map is a defensive copy; mutating it does not affect VST state.
-// Returns an empty (non-nil) map if the agent has no branches yet.
+//
+// Returns an empty (non-nil) map in two indistinguishable cases:
+//   - the agent has never been seen by the VST (no agentState entry), or
+//   - the agent has been written to but has not registered any branches.
+//
+// This is asymmetric with BranchHeadForAgent which returns ok=false on
+// both miss cases. The contract is intentional: the public API never
+// exposes whether an agent has internal state, only whether a specific
+// branch / path is registered. Callers should not conflate "agent
+// unknown" with "agent has zero branches" — the runtime treats both as
+// "nothing to return" by design.
 func (v *VST) BranchesForAgent(agent AgentId) map[BranchID]types.SnapshotID {
 	v.mu.RLock()
 	defer v.mu.RUnlock()

--- a/pkg/helios/vst/branch.go
+++ b/pkg/helios/vst/branch.go
@@ -15,6 +15,11 @@
 // Branch registry — minimal named-head primitive required by Fork.MergeInto's
 // compare-and-swap. Intentionally narrow: this is not a full reference-tracking
 // store, only the mutable pointer that VFSFork advances atomically.
+//
+// Branches are per-agent: each AgentId owns an independent (name -> SnapshotID)
+// map. The legacy single-tenant API (CreateBranch / BranchHead / Branches /
+// DeleteBranch) delegates to the AgentDefault agent. Snapshots themselves are
+// content-addressed and shared across agents via VST.snaps.
 
 package vst
 
@@ -24,17 +29,24 @@ import (
 	"github.com/good-night-oppie/helios/pkg/helios/types"
 )
 
-// CreateBranch registers a new named branch pointing at head.
+// CreateBranch registers a new named branch under the default agent.
+// Equivalent to CreateBranchForAgent(AgentDefault, name, head).
+func (v *VST) CreateBranch(name BranchID, head types.SnapshotID) error {
+	return v.CreateBranchForAgent(AgentDefault, name, head)
+}
+
+// CreateBranchForAgent registers a new named branch under the given agent.
 // Use the empty SnapshotID to create an orphan branch (Fork from "" allowed
 // only if an empty-tree snapshot has been committed; otherwise callers must
 // commit first and then CreateBranch with the resulting id).
-func (v *VST) CreateBranch(name BranchID, head types.SnapshotID) error {
+func (v *VST) CreateBranchForAgent(agent AgentId, name BranchID, head types.SnapshotID) error {
 	if name == "" {
 		return fmt.Errorf("vst.CreateBranch: empty branch name")
 	}
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	if _, ok := v.branches[name]; ok {
+	s := v.agentRW(agent)
+	if _, ok := s.branches[name]; ok {
 		return ErrBranchExists
 	}
 	if head != "" {
@@ -42,39 +54,71 @@ func (v *VST) CreateBranch(name BranchID, head types.SnapshotID) error {
 			return fmt.Errorf("vst.CreateBranch: %w (head=%s)", ErrUnknownSnapshot, head)
 		}
 	}
-	v.branches[name] = head
+	s.branches[name] = head
 	return nil
 }
 
-// BranchHead returns the current head SnapshotID for the named branch, with
-// ok=false if the branch is not registered.
+// BranchHead returns the default agent's head for the named branch.
+// Equivalent to BranchHeadForAgent(AgentDefault, name).
 func (v *VST) BranchHead(name BranchID) (types.SnapshotID, bool) {
+	return v.BranchHeadForAgent(AgentDefault, name)
+}
+
+// BranchHeadForAgent returns the named agent's head for the named branch.
+// Returns ok=false if either the agent has no state yet or the branch is
+// not registered under that agent.
+func (v *VST) BranchHeadForAgent(agent AgentId, name BranchID) (types.SnapshotID, bool) {
 	v.mu.RLock()
-	id, ok := v.branches[name]
-	v.mu.RUnlock()
+	defer v.mu.RUnlock()
+	s, ok := v.agentRO(agent)
+	if !ok {
+		return "", false
+	}
+	id, ok := s.branches[name]
 	return id, ok
 }
 
-// Branches returns a snapshot of all branch-name → head mappings.
-// The returned map is a defensive copy; mutating it does not affect VST state.
+// Branches returns a snapshot of the default agent's branch map.
+// Equivalent to BranchesForAgent(AgentDefault).
 func (v *VST) Branches() map[BranchID]types.SnapshotID {
+	return v.BranchesForAgent(AgentDefault)
+}
+
+// BranchesForAgent returns a snapshot of the named agent's branch map.
+// The returned map is a defensive copy; mutating it does not affect VST state.
+// Returns an empty (non-nil) map if the agent has no branches yet.
+func (v *VST) BranchesForAgent(agent AgentId) map[BranchID]types.SnapshotID {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
-	out := make(map[BranchID]types.SnapshotID, len(v.branches))
-	for k, v := range v.branches {
-		out[k] = v
+	s, ok := v.agentRO(agent)
+	if !ok {
+		return map[BranchID]types.SnapshotID{}
+	}
+	out := make(map[BranchID]types.SnapshotID, len(s.branches))
+	for k, val := range s.branches {
+		out[k] = val
 	}
 	return out
 }
 
-// DeleteBranch removes a registered branch. Returns ErrUnknownBranch if
-// the name is not registered.
+// DeleteBranch removes a default-agent branch.
+// Equivalent to DeleteBranchForAgent(AgentDefault, name).
 func (v *VST) DeleteBranch(name BranchID) error {
+	return v.DeleteBranchForAgent(AgentDefault, name)
+}
+
+// DeleteBranchForAgent removes the named branch from the named agent.
+// Returns ErrUnknownBranch if the branch is not registered under that agent.
+func (v *VST) DeleteBranchForAgent(agent AgentId, name BranchID) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	if _, ok := v.branches[name]; !ok {
+	s, ok := v.agentRO(agent)
+	if !ok {
 		return ErrUnknownBranch
 	}
-	delete(v.branches, name)
+	if _, ok := s.branches[name]; !ok {
+		return ErrUnknownBranch
+	}
+	delete(s.branches, name)
 	return nil
 }

--- a/pkg/helios/vst/branch.go
+++ b/pkg/helios/vst/branch.go
@@ -40,6 +40,9 @@ func (v *VST) CreateBranch(name BranchID, head types.SnapshotID) error {
 // only if an empty-tree snapshot has been committed; otherwise callers must
 // commit first and then CreateBranch with the resulting id).
 func (v *VST) CreateBranchForAgent(agent AgentId, name BranchID, head types.SnapshotID) error {
+	if err := validateAgent(agent); err != nil {
+		return err
+	}
 	if name == "" {
 		return fmt.Errorf("vst.CreateBranch: empty branch name")
 	}
@@ -68,6 +71,9 @@ func (v *VST) BranchHead(name BranchID) (types.SnapshotID, bool) {
 // Returns ok=false if either the agent has no state yet or the branch is
 // not registered under that agent.
 func (v *VST) BranchHeadForAgent(agent AgentId, name BranchID) (types.SnapshotID, bool) {
+	if validateAgent(agent) != nil {
+		return "", false
+	}
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 	s, ok := v.agentRO(agent)
@@ -98,6 +104,9 @@ func (v *VST) Branches() map[BranchID]types.SnapshotID {
 // unknown" with "agent has zero branches" — the runtime treats both as
 // "nothing to return" by design.
 func (v *VST) BranchesForAgent(agent AgentId) map[BranchID]types.SnapshotID {
+	if validateAgent(agent) != nil {
+		return map[BranchID]types.SnapshotID{}
+	}
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 	s, ok := v.agentRO(agent)
@@ -120,6 +129,9 @@ func (v *VST) DeleteBranch(name BranchID) error {
 // DeleteBranchForAgent removes the named branch from the named agent.
 // Returns ErrUnknownBranch if the branch is not registered under that agent.
 func (v *VST) DeleteBranchForAgent(agent AgentId, name BranchID) error {
+	if err := validateAgent(agent); err != nil {
+		return err
+	}
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	s, ok := v.agentRO(agent)

--- a/pkg/helios/vst/fork.go
+++ b/pkg/helios/vst/fork.go
@@ -98,7 +98,10 @@ const (
 )
 
 // Fork is a goroutine-safe copy-on-write overlay on top of a base snapshot.
+// Each fork carries the AgentId under which it was opened; MergeInto advances
+// branches only within that agent's namespace.
 type Fork struct {
+	agent      AgentId
 	base       types.SnapshotID
 	baseSnap   map[string][]byte // shared read-only ref into v.snaps[base]
 	overlay    map[string]types.Hash
@@ -113,13 +116,22 @@ type Fork struct {
 // nextForkGen is the monotonically increasing source for Fork.generation.
 var nextForkGen uint64
 
-// Fork creates a new copy-on-write overlay rooted at base.
+// Fork creates a new copy-on-write overlay rooted at base under the default
+// agent. Equivalent to ForkForAgent(AgentDefault, base).
+func (v *VST) Fork(base types.SnapshotID) (*Fork, error) {
+	return v.ForkForAgent(AgentDefault, base)
+}
+
+// ForkForAgent creates a new copy-on-write overlay rooted at base under the
+// named agent. The fork's MergeInto will advance only branches registered
+// under this agent; cross-agent branches are not visible.
+//
 // The base snapshot must exist either in-memory or in the attached L2 store.
 // Multiple Forks from the same base may be used concurrently.
 //
 // Discard MUST be called when the fork is no longer needed; a runtime finalizer
 // is wired as a defensive safety net but should not be relied upon.
-func (v *VST) Fork(base types.SnapshotID) (*Fork, error) {
+func (v *VST) ForkForAgent(agent AgentId, base types.SnapshotID) (*Fork, error) {
 	v.mu.RLock()
 	snap, ok := v.snaps[base]
 	v.mu.RUnlock()
@@ -133,6 +145,7 @@ func (v *VST) Fork(base types.SnapshotID) (*Fork, error) {
 	}
 
 	f := &Fork{
+		agent:      normaliseAgent(agent),
 		base:       base,
 		baseSnap:   snap, // immutable reference; safe to share across forks
 		overlay:    make(map[string]types.Hash),
@@ -144,6 +157,9 @@ func (v *VST) Fork(base types.SnapshotID) (*Fork, error) {
 	runtime.SetFinalizer(f, func(g *Fork) { g.Discard() })
 	return f, nil
 }
+
+// Agent returns the AgentId this fork was opened under.
+func (f *Fork) Agent() AgentId { return f.agent }
 
 // Base returns the immutable base snapshot id this fork was created from.
 func (f *Fork) Base() types.SnapshotID { return f.base }
@@ -356,7 +372,8 @@ func (f *Fork) MergeInto(branch BranchID) (types.SnapshotID, error) {
 
 	// --- Phase 3: atomic CAS on branch head + install snapshot in VST ---
 	v.mu.Lock()
-	cur, ok := v.branches[branch]
+	agentState := v.agentRW(f.agent)
+	cur, ok := agentState.branches[branch]
 	if !ok {
 		v.mu.Unlock()
 		return "", ErrUnknownBranch
@@ -373,9 +390,9 @@ func (f *Fork) MergeInto(branch BranchID) (types.SnapshotID, error) {
 	}
 	v.snaps[newID] = storedSnap
 	for path, h := range overlayCopy {
-		v.pathToHash[path] = h
+		agentState.pathToHash[path] = h
 	}
-	v.branches[branch] = newID
+	agentState.branches[branch] = newID
 	l2 := v.l2
 	v.mu.Unlock()
 

--- a/pkg/helios/vst/fork.go
+++ b/pkg/helios/vst/fork.go
@@ -132,6 +132,9 @@ func (v *VST) Fork(base types.SnapshotID) (*Fork, error) {
 // Discard MUST be called when the fork is no longer needed; a runtime finalizer
 // is wired as a defensive safety net but should not be relied upon.
 func (v *VST) ForkForAgent(agent AgentId, base types.SnapshotID) (*Fork, error) {
+	if err := validateAgent(agent); err != nil {
+		return nil, err
+	}
 	v.mu.RLock()
 	snap, ok := v.snaps[base]
 	v.mu.RUnlock()

--- a/pkg/helios/vst/vst.go
+++ b/pkg/helios/vst/vst.go
@@ -44,26 +44,30 @@ func dprintf(format string, a ...any) {
 var _ types.StateManager = (*VST)(nil)
 
 // VST is an in-memory Virtual State Tree used for fast user-space snapshots.
+//
+// Multi-tenancy: per-tenant working state lives in `agents`, keyed by AgentId.
+// The legacy single-tenant API resolves to AgentDefault. Snapshots remain
+// content-addressed and shared across agents via the global `snaps` table so
+// that identical content from any agent yields the same SnapshotID.
 type VST struct {
-	cur        map[string][]byte                      // current working set
-	snaps      map[types.SnapshotID]map[string][]byte // snapshot store
-	branches   map[BranchID]types.SnapshotID          // named branch heads (advanced by Fork.MergeInto)
-	l1         l1cache.Cache                          // L1 cache (hot data)
-	l2         objstore.Store                         // L2 persistent store
-	pathToHash map[string]types.Hash                  // path -> content hash mapping for L1/L2 retrieval
-	em         *metrics.EngineMetrics                 // engine metrics collector
-	mu         sync.RWMutex                           // protects cur, pathToHash, snaps, and branches
+	agents map[AgentId]*agentState                // per-agent cur / pathToHash / branches
+	snaps  map[types.SnapshotID]map[string][]byte // snapshot store — global, content-addressed
+	l1     l1cache.Cache                          // L1 cache (hot data)
+	l2     objstore.Store                         // L2 persistent store
+	em     *metrics.EngineMetrics                 // engine metrics collector
+	mu     sync.RWMutex                           // protects agents (and each agentState), snaps
 }
 
-// New returns a fresh VST.
+// New returns a fresh VST with the default agent pre-created so the legacy
+// single-tenant API is immediately usable without an extra allocation.
 func New() *VST {
-	return &VST{
-		cur:        make(map[string][]byte),
-		snaps:      make(map[types.SnapshotID]map[string][]byte),
-		branches:   make(map[BranchID]types.SnapshotID),
-		pathToHash: make(map[string]types.Hash),
-		em:         metrics.NewEngineMetrics(),
+	v := &VST{
+		agents: make(map[AgentId]*agentState),
+		snaps:  make(map[types.SnapshotID]map[string][]byte),
+		em:     metrics.NewEngineMetrics(),
 	}
+	v.agents[AgentDefault] = newAgentState()
+	return v
 }
 
 // AttachStores attaches L1 cache and L2 object store to the VST.
@@ -75,30 +79,63 @@ func (v *VST) AttachStores(l1 l1cache.Cache, l2 objstore.Store) {
 	}
 }
 
-// WriteFile writes/overwrites a file in the current working set (in memory).
+// WriteFile writes/overwrites a file in the default agent's working set.
+// Equivalent to WriteFileForAgent(AgentDefault, path, content).
 func (v *VST) WriteFile(path string, content []byte) error {
+	return v.WriteFileForAgent(AgentDefault, path, content)
+}
+
+// WriteFileForAgent writes/overwrites a file in the named agent's working
+// set (in memory only). The agent's per-tenant state is lazily created on
+// first write.
+func (v *VST) WriteFileForAgent(agent AgentId, path string, content []byte) error {
 	cp := make([]byte, len(content))
 	copy(cp, content)
 	v.mu.Lock()
-	v.cur[path] = cp
+	v.agentRW(agent).cur[path] = cp
 	v.mu.Unlock()
 	return nil
 }
 
-// DeleteFile removes a file from the current working set.
+// DeleteFile removes a file from the default agent's working set.
+// Equivalent to DeleteFileForAgent(AgentDefault, path).
 func (v *VST) DeleteFile(path string) {
+	v.DeleteFileForAgent(AgentDefault, path)
+}
+
+// DeleteFileForAgent removes a file from the named agent's working set.
+// No-op for unknown agents (no state to delete from).
+func (v *VST) DeleteFileForAgent(agent AgentId, path string) {
 	v.mu.Lock()
-	delete(v.cur, path)
+	if s, ok := v.agentRO(agent); ok {
+		delete(s.cur, path)
+	}
 	v.mu.Unlock()
 }
 
-// ReadFile reads a file from the current working set (copy returned).
-// If the file is not in memory but we have stores attached, it tries L1 then L2.
+// ReadFile reads a file from the default agent's working set (copy returned).
+// Equivalent to ReadFileForAgent(AgentDefault, path).
+// If the file is not in memory but L1/L2 stores are attached, it tries L1 then L2.
 func (v *VST) ReadFile(path string) ([]byte, error) {
+	return v.ReadFileForAgent(AgentDefault, path)
+}
+
+// ReadFileForAgent reads a file from the named agent's working set.
+// If the file is not in memory but L1/L2 stores are attached, it tries
+// L1 then L2 via the agent's path-to-hash map.
+func (v *VST) ReadFileForAgent(agent AgentId, path string) ([]byte, error) {
 	// First check current working set
 	v.mu.RLock()
-	b, ok := v.cur[path]
-	hash, hasHash := v.pathToHash[path]
+	var (
+		b       []byte
+		ok      bool
+		hash    types.Hash
+		hasHash bool
+	)
+	if s, agentOk := v.agentRO(agent); agentOk {
+		b, ok = s.cur[path]
+		hash, hasHash = s.pathToHash[path]
+	}
 	v.mu.RUnlock()
 
 	if ok {
@@ -140,19 +177,38 @@ func (v *VST) ReadFile(path string) ([]byte, error) {
 	return nil, nil // Not found anywhere
 }
 
-// Commit creates a snapshot and returns a content-addressed SnapshotID (Merkle root).
+// Commit creates a snapshot of the default agent's working set and returns
+// a content-addressed SnapshotID (Merkle root). Equivalent to
+// CommitForAgent(AgentDefault, msg).
 func (v *VST) Commit(msg string) (types.SnapshotID, types.CommitMetrics, error) {
+	return v.CommitForAgent(AgentDefault, msg)
+}
+
+// CommitForAgent creates a snapshot of the named agent's working set.
+// The returned SnapshotID is content-addressed: identical content from
+// any agent yields the same SnapshotID and shares storage in v.snaps.
+func (v *VST) CommitForAgent(agent AgentId, msg string) (types.SnapshotID, types.CommitMetrics, error) {
+	_ = msg // commit message currently unused (parity with Commit)
 	start := time.Now()
 
 	// Deep copy current working set for the stored snapshot (restore/materialize rely on this).
 	v.mu.RLock()
-	snap := make(map[string][]byte, len(v.cur))
-	var newBytes int64
-	for k, val := range v.cur {
-		cp := make([]byte, len(val))
-		copy(cp, val)
-		snap[k] = cp
-		newBytes += int64(len(cp))
+	var (
+		snap     map[string][]byte
+		newBytes int64
+	)
+	if s, ok := v.agentRO(agent); ok {
+		snap = make(map[string][]byte, len(s.cur))
+		for k, val := range s.cur {
+			cp := make([]byte, len(val))
+			copy(cp, val)
+			snap[k] = cp
+			newBytes += int64(len(cp))
+		}
+	} else {
+		// Unknown agent: commit an empty working set (matches single-tenant
+		// behaviour where a fresh VST commits to the empty-tree snapshot).
+		snap = map[string][]byte{}
 	}
 	v.mu.RUnlock()
 
@@ -181,8 +237,11 @@ func (v *VST) Commit(msg string) (types.SnapshotID, types.CommitMetrics, error) 
 
 	// Store path->hash mapping for L1/L2 retrieval (must be done with lock)
 	v.mu.Lock()
-	for path, h := range blobHashByPath {
-		v.pathToHash[path] = h
+	{
+		s := v.agentRW(agent)
+		for path, h := range blobHashByPath {
+			s.pathToHash[path] = h
+		}
 	}
 	v.mu.Unlock()
 
@@ -353,27 +412,34 @@ func depth(p string) int {
 	return strings.Count(filepath.Clean(p), string(os.PathSeparator))
 }
 
-// Restore replaces the current working set with the files from the given snapshot
-// and writes them to the filesystem. This is equivalent to calling RestoreWithOpts
-// with default options (WriteToFilesystem=true).
+// Restore replaces the default agent's working set with the files from the given
+// snapshot and writes them to the filesystem. Equivalent to RestoreWithOpts with
+// WriteToFilesystem=true.
 func (v *VST) Restore(id types.SnapshotID) error {
-	// Call RestoreWithOpts with default options for backward compatibility
 	return v.RestoreWithOpts(id, types.RestoreOpts{WriteToFilesystem: true})
 }
 
-// RestoreWithOpts replaces the current working set with files from the given snapshot.
-// The behavior can be controlled via RestoreOpts:
-// - DryRun: when true, only restores to memory without filesystem writes
-// - WriteToFilesystem: when true (default), writes restored files to disk atomically
+// RestoreWithOpts replaces the default agent's working set with the snapshot's
+// contents. Equivalent to RestoreForAgent(AgentDefault, id, opts).
 func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error {
+	return v.RestoreForAgent(AgentDefault, id, opts)
+}
+
+// RestoreForAgent replaces the named agent's working set with the snapshot's
+// contents. Behaviour mirrors RestoreWithOpts.
+// - DryRun: when true, only restores to memory without filesystem writes
+// - WriteToFilesystem: when true, writes restored files to disk atomically
+func (v *VST) RestoreForAgent(agent AgentId, id types.SnapshotID, opts types.RestoreOpts) error {
 	v.mu.RLock()
 	base, ok := v.snaps[id]
 	dprintf("starting restore of snapshot %s (in-memory snapshots=%d)", id, len(v.snaps))
 
 	// Save the old tracked files before they get overwritten (for stale file cleanup)
 	oldTrackedFiles := make(map[string]bool)
-	for path := range v.cur {
-		oldTrackedFiles[path] = true
+	if s, agentOk := v.agentRO(agent); agentOk {
+		for path := range s.cur {
+			oldTrackedFiles[path] = true
+		}
 	}
 	v.mu.RUnlock()
 
@@ -422,10 +488,11 @@ func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error
 				restoredContent[path] = data
 			}
 
-			// Reset working state and use snapshot metadata as path→hash mapping
+			// Reset agent working state and use snapshot metadata as path→hash mapping
 			v.mu.Lock()
-			v.cur = restoredContent
-			v.pathToHash = snapshotData
+			s := v.agentRW(agent)
+			s.cur = restoredContent
+			s.pathToHash = snapshotData
 			v.mu.Unlock()
 		}
 	} else {
@@ -445,8 +512,9 @@ func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error
 			pathHashes[k] = h
 		}
 		v.mu.Lock()
-		v.cur = next
-		v.pathToHash = pathHashes
+		s := v.agentRW(agent)
+		s.cur = next
+		s.pathToHash = pathHashes
 		v.mu.Unlock()
 		restoredContent = next
 	}

--- a/pkg/helios/vst/vst.go
+++ b/pkg/helios/vst/vst.go
@@ -89,6 +89,9 @@ func (v *VST) WriteFile(path string, content []byte) error {
 // set (in memory only). The agent's per-tenant state is lazily created on
 // first write.
 func (v *VST) WriteFileForAgent(agent AgentId, path string, content []byte) error {
+	if err := validateAgent(agent); err != nil {
+		return err
+	}
 	cp := make([]byte, len(content))
 	copy(cp, content)
 	v.mu.Lock()
@@ -104,8 +107,12 @@ func (v *VST) DeleteFile(path string) {
 }
 
 // DeleteFileForAgent removes a file from the named agent's working set.
-// No-op for unknown agents (no state to delete from).
+// No-op for unknown agents (no state to delete from) and silently skips
+// invalid (non-UTF-8) AgentIds since this method does not return an error.
 func (v *VST) DeleteFileForAgent(agent AgentId, path string) {
+	if validateAgent(agent) != nil {
+		return
+	}
 	v.mu.Lock()
 	if s, ok := v.agentRO(agent); ok {
 		delete(s.cur, path)
@@ -124,6 +131,9 @@ func (v *VST) ReadFile(path string) ([]byte, error) {
 // If the file is not in memory but L1/L2 stores are attached, it tries
 // L1 then L2 via the agent's path-to-hash map.
 func (v *VST) ReadFileForAgent(agent AgentId, path string) ([]byte, error) {
+	if err := validateAgent(agent); err != nil {
+		return nil, err
+	}
 	// First check current working set
 	v.mu.RLock()
 	var (
@@ -188,6 +198,9 @@ func (v *VST) Commit(msg string) (types.SnapshotID, types.CommitMetrics, error) 
 // The returned SnapshotID is content-addressed: identical content from
 // any agent yields the same SnapshotID and shares storage in v.snaps.
 func (v *VST) CommitForAgent(agent AgentId, msg string) (types.SnapshotID, types.CommitMetrics, error) {
+	if err := validateAgent(agent); err != nil {
+		return "", types.CommitMetrics{}, err
+	}
 	_ = msg // commit message currently unused (parity with Commit)
 	start := time.Now()
 
@@ -430,6 +443,9 @@ func (v *VST) RestoreWithOpts(id types.SnapshotID, opts types.RestoreOpts) error
 // - DryRun: when true, only restores to memory without filesystem writes
 // - WriteToFilesystem: when true, writes restored files to disk atomically
 func (v *VST) RestoreForAgent(agent AgentId, id types.SnapshotID, opts types.RestoreOpts) error {
+	if err := validateAgent(agent); err != nil {
+		return err
+	}
 	v.mu.RLock()
 	base, ok := v.snaps[id]
 	dprintf("starting restore of snapshot %s (in-memory snapshots=%d)", id, len(v.snaps))

--- a/pkg/helios/vst/vst.go
+++ b/pkg/helios/vst/vst.go
@@ -109,6 +109,11 @@ func (v *VST) DeleteFile(path string) {
 // DeleteFileForAgent removes a file from the named agent's working set.
 // No-op for unknown agents (no state to delete from) and silently skips
 // invalid (non-UTF-8) AgentIds since this method does not return an error.
+//
+// Both s.cur AND s.pathToHash must be cleared. Without the second delete,
+// a path that survives a prior Commit (cur is swapped empty but pathToHash
+// retains path→hash) would still be readable from L1/L2 via
+// ReadFileForAgent's fallback, violating working-set delete semantics.
 func (v *VST) DeleteFileForAgent(agent AgentId, path string) {
 	if validateAgent(agent) != nil {
 		return
@@ -116,6 +121,7 @@ func (v *VST) DeleteFileForAgent(agent AgentId, path string) {
 	v.mu.Lock()
 	if s, ok := v.agentRO(agent); ok {
 		delete(s.cur, path)
+		delete(s.pathToHash, path)
 	}
 	v.mu.Unlock()
 }

--- a/pkg/helios/vst/vst_optimized.go
+++ b/pkg/helios/vst/vst_optimized.go
@@ -38,33 +38,43 @@ func (v *VST) CommitOptimized(msg string) (types.SnapshotID, types.CommitMetrics
 }
 
 // CommitOptimizedForAgent is the agent-aware variant of CommitOptimized.
+//
+// Locking discipline mirrors CommitForAgent: short critical sections around
+// every mutation of `v.agents`, `agentState.cur`, `agentState.pathToHash`,
+// and `v.snaps`. Pure-CPU work (hashing, Merkle-tree build) and L2 I/O
+// (PutBatch) happen outside the lock so concurrent agents do not block on
+// each other for the slow path.
+//
+// Pre-VA-1a this function was already racy on `v.cur` / `v.pathToHash` /
+// `v.snaps`. With multi-tenant `agents` map it became fatally racy because
+// `agentRW` lazily inserts into `v.agents` — an unlocked insert collides
+// with a concurrent map write and panics. Locking is now mandatory.
 func (v *VST) CommitOptimizedForAgent(agent AgentId, msg string) (types.SnapshotID, types.CommitMetrics, error) {
 	_ = msg // commit message currently unused (parity with Commit)
 	start := time.Now()
 
-	// OPTIMIZATION 1: Copy-on-Write (COW) snapshot
-	// Instead of deep copying, share references and create new working set
+	// Phase 1 — COW snapshot of cur under write lock.
+	// agentRW may mutate v.agents; the cur reference swap mutates agentState.
+	v.mu.Lock()
 	s := v.agentRW(agent)
-	snap := s.cur                                  // Share reference to current working set
-	s.cur = make(map[string][]byte, len(snap))     // New working set for future modifications
+	snap := s.cur                              // Share reference to current working set
+	s.cur = make(map[string][]byte, len(snap)) // New working set for future modifications
+	v.mu.Unlock()
 
 	var newBytes int64
 	for _, val := range snap {
 		newBytes += int64(len(val))
 	}
 
-	// OPTIMIZATION 2: Batch compute all blob hashes
+	// Phase 2 — hash all blobs (pure CPU, no shared state mutated).
 	blobHashByPath := make(map[string]types.Hash, len(snap))
 	blobsToStore := make([]objstore.BatchEntry, 0, len(snap))
-
 	for path, content := range snap {
 		h, err := util.HashBlob(content)
 		if err != nil {
 			return "", types.CommitMetrics{}, err
 		}
 		blobHashByPath[path] = h
-		s.pathToHash[path] = h
-
 		if v.l2 != nil {
 			blobsToStore = append(blobsToStore, objstore.BatchEntry{
 				Hash:  h,
@@ -73,41 +83,49 @@ func (v *VST) CommitOptimizedForAgent(agent AgentId, msg string) (types.Snapshot
 		}
 	}
 
-	// Store blobs in L2 if attached
+	// Phase 3 — install pathToHash under write lock. `s` ptr captured in
+	// Phase 1 is stable because agentRW never replaces an existing
+	// agentState, only inserts a new one if absent.
+	v.mu.Lock()
+	for path, h := range blobHashByPath {
+		s.pathToHash[path] = h
+	}
+	v.mu.Unlock()
+
+	// Phase 4 — L2 blob batch (outside lock; I/O dominates).
 	if v.l2 != nil && len(blobsToStore) > 0 {
 		if err := v.l2.PutBatch(blobsToStore); err != nil {
 			return "", types.CommitMetrics{}, fmt.Errorf("failed to store blobs in L2: %w", err)
 		}
 	}
 
-	// OPTIMIZATION 3: Efficient O(n) directory tree building
+	// Phase 5 — O(n) Merkle tree build (pure CPU).
 	root, err := v.buildDirectoryTreeOptimized(blobHashByPath)
 	if err != nil {
 		return "", types.CommitMetrics{}, err
 	}
-
 	id := types.SnapshotID(root.String())
 
-	// Store snapshot metadata in L2
+	// Phase 6 — L2 snapshot metadata (outside lock).
 	if v.l2 != nil {
 		metadataBytes, err := json.Marshal(blobHashByPath)
 		if err != nil {
 			return "", types.CommitMetrics{}, fmt.Errorf("failed to marshal snapshot metadata: %w", err)
 		}
-		
 		snapshotKey := "snapshot:" + string(id)
 		snapshotMetadata := []objstore.BatchEntry{{
-			Hash: types.Hash{Algorithm: types.BLAKE3, Digest: []byte(snapshotKey)},
+			Hash:  types.Hash{Algorithm: types.BLAKE3, Digest: []byte(snapshotKey)},
 			Value: metadataBytes,
 		}}
-		
 		if err := v.l2.PutBatch(snapshotMetadata); err != nil {
 			return "", types.CommitMetrics{}, fmt.Errorf("failed to store snapshot metadata: %w", err)
 		}
 	}
 
-	// Store snapshot using COW reference
+	// Phase 7 — install v.snaps[id] under write lock (shared snap store).
+	v.mu.Lock()
 	v.snaps[id] = snap
+	v.mu.Unlock()
 
 	commitMetrics := types.CommitMetrics{
 		CommitLatency: time.Since(start),

--- a/pkg/helios/vst/vst_optimized.go
+++ b/pkg/helios/vst/vst_optimized.go
@@ -27,18 +27,27 @@ import (
 )
 
 // CommitOptimized is a high-performance version of Commit that achieves <70μs targets
+// for the default agent's working set.
+// Equivalent to CommitOptimizedForAgent(AgentDefault, msg).
 // Key optimizations:
-// 1. O(n²) → O(n) directory tree building 
+// 1. O(n²) → O(n) directory tree building
 // 2. Copy-on-Write (COW) semantics for snapshots
 // 3. Efficient parent-child directory mapping
 func (v *VST) CommitOptimized(msg string) (types.SnapshotID, types.CommitMetrics, error) {
+	return v.CommitOptimizedForAgent(AgentDefault, msg)
+}
+
+// CommitOptimizedForAgent is the agent-aware variant of CommitOptimized.
+func (v *VST) CommitOptimizedForAgent(agent AgentId, msg string) (types.SnapshotID, types.CommitMetrics, error) {
+	_ = msg // commit message currently unused (parity with Commit)
 	start := time.Now()
 
 	// OPTIMIZATION 1: Copy-on-Write (COW) snapshot
 	// Instead of deep copying, share references and create new working set
-	snap := v.cur  // Share reference to current working set
-	v.cur = make(map[string][]byte, len(snap)) // New working set for future modifications
-	
+	s := v.agentRW(agent)
+	snap := s.cur                                  // Share reference to current working set
+	s.cur = make(map[string][]byte, len(snap))     // New working set for future modifications
+
 	var newBytes int64
 	for _, val := range snap {
 		newBytes += int64(len(val))
@@ -47,14 +56,14 @@ func (v *VST) CommitOptimized(msg string) (types.SnapshotID, types.CommitMetrics
 	// OPTIMIZATION 2: Batch compute all blob hashes
 	blobHashByPath := make(map[string]types.Hash, len(snap))
 	blobsToStore := make([]objstore.BatchEntry, 0, len(snap))
-	
+
 	for path, content := range snap {
 		h, err := util.HashBlob(content)
 		if err != nil {
 			return "", types.CommitMetrics{}, err
 		}
 		blobHashByPath[path] = h
-		v.pathToHash[path] = h
+		s.pathToHash[path] = h
 
 		if v.l2 != nil {
 			blobsToStore = append(blobsToStore, objstore.BatchEntry{

--- a/pkg/helios/vst/vst_optimized.go
+++ b/pkg/helios/vst/vst_optimized.go
@@ -50,6 +50,9 @@ func (v *VST) CommitOptimized(msg string) (types.SnapshotID, types.CommitMetrics
 // `agentRW` lazily inserts into `v.agents` — an unlocked insert collides
 // with a concurrent map write and panics. Locking is now mandatory.
 func (v *VST) CommitOptimizedForAgent(agent AgentId, msg string) (types.SnapshotID, types.CommitMetrics, error) {
+	if err := validateAgent(agent); err != nil {
+		return "", types.CommitMetrics{}, err
+	}
 	_ = msg // commit message currently unused (parity with Commit)
 	start := time.Now()
 


### PR DESCRIPTION
## Summary

Helios PR-VA-1a — Go-side half of multi-tenant `AgentId` plumbing through the VST. This is Vector A gap #1 from [HANDOFF_FROM_HELIOS.md](../HANDOFF_FROM_HELIOS.md) (see also `~/gh/ionq/.cursor/plans/2026-05-25_helios-integration-codex-lens.md`). The FFI + Rust safe-wrapper exposure follows in PR-VA-1b.

**Design (operator-chosen 2026-05-26):**
- (1a) Single `VST`, multi-tenant via composite key. `agents map[AgentId]*agentState` partitions `cur`/`pathToHash`/`branches`. Snapshots remain content-addressed and shared globally — identical content from any agent → same `SnapshotID`.
- (2a) String newtype `type AgentId string` + `const AgentDefault AgentId = "default"`.
- (3a) Default-agent passthrough: every existing single-tenant method (`WriteFile`, `ReadFile`, `DeleteFile`, `Commit`, `Restore`, `CreateBranch`, `BranchHead`, `Branches`, `DeleteBranch`, `Fork`, `CommitOptimized`) keeps working unchanged by delegating to `*ForAgent(AgentDefault, …)`. Empty `AgentId` normalises to `AgentDefault`.

## Surface added

| Layer | Method |
|---|---|
| VST | `WriteFileForAgent`, `ReadFileForAgent`, `DeleteFileForAgent` |
| VST | `CommitForAgent`, `RestoreForAgent`, `CommitOptimizedForAgent` |
| Branch | `CreateBranchForAgent`, `BranchHeadForAgent`, `BranchesForAgent`, `DeleteBranchForAgent` |
| Fork | `ForkForAgent(agent, base)`, `Fork.Agent()` accessor |

## Tests

`pkg/helios/vst/agent_test.go` adds six scenarios:

| Test | Asserts |
|---|---|
| `TestVST_AgentPathIsolation` | Two agents write same path → distinct content |
| `TestVST_DefaultAgentPassthrough` | Legacy API ↔ `*ForAgent(AgentDefault, …)` interchangeable |
| `TestVST_AgentBranchIsolation` | Same branch name under different agents → different heads |
| `TestFork_AgentScopedMergeInto` | `fork.agent` scopes `MergeInto`; cross-agent branch invisible → `ErrUnknownBranch` |
| `TestVST_AgentCommitSharedSnapshot` | Identical content from two agents → same `SnapshotID` (content-addressed dedup preserved) |
| `TestVST_ConcurrentAgentsWrites` | K=8 × N=200 writers under `-race` |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=5 ./pkg/helios/vst/...` → 6.3s green
- [x] `make ffi-archive` clean
- [x] `cargo test --release` in `bindings/rust/` → 3/3 pass (single-tenant Rust path verified backwards-compat via `AgentDefault` passthrough)

## Out of scope (follow-up PRs)

- **PR-VA-1b** — FFI symbols (`helios_vst_*_for_agent`) + `helios-sys` raw extern + `helios-rs` safe wrapper
- **PR-VA-2** — FastCDC chunking
- **PR-VA-3** — `Vst::diff(from, to)` FFI
- **PR-VA-4** — `commit_with_metadata` for ionq event-watermark bundling
- **PR-VA-5** — `cargo bench` vs SQLite-blob baseline
- **PR-VA-6** — reachable-root blob GC

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)