### PR TITLE
ci(claude-review): force Node 24 to bypass upstream Node 20 fs bug

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,12 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
+    env:
+      # Force Node 24 to bypass Node 20 fs consistency bug that trips
+      # anthropics/claude-code-action@v1's bundled tsconfig.json read:
+      #   "Internal error: directory mismatch for directory
+      #    /home/runner/work/_actions/anthropics/claude-code-action/v1/tsconfig.json, fd 4"
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` as a job-level `env:` on the `claude-review` job.
- Workaround for a Node 20 fs consistency bug inside `anthropics/claude-code-action@v1` that crashes the action with:
  ```
  Internal error: directory mismatch for directory
  /home/runner/work/_actions/anthropics/claude-code-action/v1/tsconfig.json, fd 4
  ```
- PR #45 (merged) addressed the auth path (switch to `ANTHROPIC_API_KEY`) but did NOT include this flag — claude-review is still red on PR #46 and will be on every future PR until this lands.

## Affected
- #46 (`feat/agent-id-thread-through`) — claude-review currently failing on this exact error.
- All future PRs touching this workflow until merged.

## Scope
- One file: `.github/workflows/claude-code-review.yml`
- Six new lines (env block + comment).
- `cursor-review.yml` intentionally untouched — separate `CURSOR_API_KEY` rotation issue, operator-only.

## Test plan
- [ ] Merge → re-trigger claude-review on PR #46 → confirm action runs to completion (no `directory mismatch` error).
- [ ] Open any new PR after merge → confirm claude-review green.

Draft until reviewed. Operator (Eddie) merges.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)