### PR TITLE
ci(claude-review): switch to CLAUDE_CODE_OAUTH_TOKEN, drop stale ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,10 +41,11 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          # Prefer ANTHROPIC_API_KEY when set (required for orgs that have
-          # disabled Claude subscription access for Claude Code); fall back
-          # to OAuth token for personal / subscription-enabled accounts.
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Auth via CLAUDE_CODE_OAUTH_TOKEN (subscription / personal token).
+          # ANTHROPIC_API_KEY path was removed: the repo secret was invalid
+          # ("Claude Code returned an error result: Invalid API key") and the
+          # OAuth token is the active credential. Re-add the api_key line if
+          # an org-managed API key is rotated in.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'


### PR DESCRIPTION
## Summary
- Remove the `anthropic_api_key:` input from the `claude-review` job — the `ANTHROPIC_API_KEY` repo secret is stale/invalid.
- `CLAUDE_CODE_OAUTH_TOKEN` (subscription / personal token, fresh in vault — updated 19:40 UTC vs ANTHROPIC_API_KEY 08:22 UTC) becomes the sole credential path.
- Effectively reverts PR #45 for this workflow. Inline comment kept so a rotated org API key can be re-introduced by uncommenting one line.

## Root cause
PR #46 claude-review fails with:
```
error: Claude Code returned an error result: Invalid API key
· Fix external API key
##[error]Action failed with error: SDK execution error: Error: Claude Code returned an error result: Invalid API key
```
The action prefers `anthropic_api_key` over `claude_code_oauth_token` when both are set, so the OAuth fallback never activates. Drop the api_key line → action picks up OAuth → auth succeeds.

## Diff
```diff
-          # Prefer ANTHROPIC_API_KEY when set (required for orgs that have
-          # disabled Claude subscription access for Claude Code); fall back
-          # to OAuth token for personal / subscription-enabled accounts.
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Auth via CLAUDE_CODE_OAUTH_TOKEN (subscription / personal token).
+          # ANTHROPIC_API_KEY path was removed: the repo secret was invalid
+          # ("Claude Code returned an error result: Invalid API key") and the
+          # OAuth token is the active credential. Re-add the api_key line if
+          # an org-managed API key is rotated in.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

## Affected
- #46 (`feat/agent-id-thread-through`) — currently red on this exact `Invalid API key` error.
- All future PRs until an org-managed `ANTHROPIC_API_KEY` is rotated in.

## Note on PR #46 sync
PR #46 head is still based on `bdddd20` (pre Node 24 flag from #47). After merging this PR, master will be sync'd into `feat/agent-id-thread-through` so #46 picks up both the Node 24 flag and the OAuth fix.

## Test plan
- [ ] Merge → master will trigger claude-review for any new PR.
- [ ] Sync master into PR #46 → claude-review on #46 re-runs → confirm green.

Draft until reviewed. Operator (Eddie) merges.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)