### PR TITLE
feat(ffi): thread AgentId through Rust/CGO FFI (PR-VA-1a)

### DIFF
--- a/bindings/rust/helios-sys/src/lib.rs
+++ b/bindings/rust/helios-sys/src/lib.rs
@@ -43,13 +43,35 @@ extern "C" {
         data: *const c_uchar,
         length: usize,
     ) -> c_int;
+    pub fn helios_vst_write_file_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
+        path: *const c_char,
+        data: *const c_uchar,
+        length: usize,
+    ) -> c_int;
     pub fn helios_vst_read_file(
         h: helios_vst_t,
         path: *const c_char,
         out_buf: *mut *mut c_uchar,
         out_len: *mut usize,
     ) -> c_int;
+    pub fn helios_vst_read_file_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
+        path: *const c_char,
+        out_buf: *mut *mut c_uchar,
+        out_len: *mut usize,
+    ) -> c_int;
     pub fn helios_vst_delete_file(h: helios_vst_t, path: *const c_char) -> c_int;
+    pub fn helios_vst_delete_file_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
+        path: *const c_char,
+    ) -> c_int;
 
     // -- VST commit / restore --------------------------------------------
     pub fn helios_vst_commit(
@@ -58,8 +80,23 @@ extern "C" {
         out_id: *mut *mut c_char,
         out_len: *mut usize,
     ) -> c_int;
+    pub fn helios_vst_commit_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
+        msg: *const c_char,
+        out_id: *mut *mut c_char,
+        out_len: *mut usize,
+    ) -> c_int;
     pub fn helios_vst_restore_memory(
         h: helios_vst_t,
+        id: *const c_char,
+        id_len: usize,
+    ) -> c_int;
+    pub fn helios_vst_restore_memory_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
         id: *const c_char,
         id_len: usize,
     ) -> c_int;
@@ -71,8 +108,24 @@ extern "C" {
         head: *const c_char,
         head_len: usize,
     ) -> c_int;
+    pub fn helios_vst_create_branch_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
+        name: *const c_char,
+        head: *const c_char,
+        head_len: usize,
+    ) -> c_int;
     pub fn helios_vst_branch_head(
         h: helios_vst_t,
+        name: *const c_char,
+        out_id: *mut *mut c_char,
+        out_len: *mut usize,
+    ) -> c_int;
+    pub fn helios_vst_branch_head_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
         name: *const c_char,
         out_id: *mut *mut c_char,
         out_len: *mut usize,
@@ -81,6 +134,14 @@ extern "C" {
     // -- Fork lifecycle ---------------------------------------------------
     pub fn helios_fork_new(
         h: helios_vst_t,
+        base: *const c_char,
+        base_len: usize,
+        out_fork: *mut helios_fork_t,
+    ) -> c_int;
+    pub fn helios_fork_new_for_agent(
+        h: helios_vst_t,
+        agent_ptr: *const c_char,
+        agent_len: usize,
         base: *const c_char,
         base_len: usize,
         out_fork: *mut helios_fork_t,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -90,6 +90,44 @@ impl From<String> for SnapshotId {
     }
 }
 
+/// AgentId names a tenant in the multi-tenant VST namespace.
+///
+/// Identical to the Go-side `vst.AgentId` (string newtype). String form
+/// is sent across FFI as a (ptr, len) pair so embedded NUL bytes are
+/// not required to be encoded. The reserved value `"default"` (also
+/// available via `AgentId::default()` or `AGENT_DEFAULT`) is the agent
+/// the legacy single-tenant API resolves to, so legacy callers and
+/// new multi-tenant callers see the same data when they share that ID.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct AgentId(pub String);
+
+/// Reserved agent string used by the legacy single-tenant API.
+pub const AGENT_DEFAULT: &str = "default";
+
+impl From<&str> for AgentId {
+    fn from(s: &str) -> Self {
+        AgentId(s.to_owned())
+    }
+}
+
+impl From<String> for AgentId {
+    fn from(s: String) -> Self {
+        AgentId(s)
+    }
+}
+
+impl Default for AgentId {
+    fn default() -> Self {
+        AgentId(AGENT_DEFAULT.to_owned())
+    }
+}
+
+impl fmt::Display for AgentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// BranchId names a mutable head pointer.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct BranchId(pub String);
@@ -221,6 +259,195 @@ impl Vst {
                 self.handle,
                 bytes.as_ptr() as *const i8,
                 bytes.len(),
+                &mut fh,
+            )
+        };
+        rc_to_result(rc)?;
+        Ok(Fork {
+            handle: fh,
+            _vst: std::marker::PhantomData,
+        })
+    }
+
+    // -- Per-agent (multi-tenant) variants -------------------------------
+    //
+    // Each method targets a specific AgentId tenant in the VST namespace,
+    // mirroring the Go-side `*ForAgent` API (PR-VA-1a, #46). The AgentId
+    // string crosses FFI as a (ptr, len) pair — NOT a NUL-terminated CString
+    // — so interior NUL bytes need no escaping and the Go side decodes it with
+    // `goStringFromCN`. An empty AgentId is sent as (NULL, 0); the Go side
+    // normalises both "" and "default" to AGENT_DEFAULT, so the legacy
+    // non-agent methods above and `AgentId::default()` resolve to one tenant.
+
+    /// Write `data` at `path` in `agent`'s working set.
+    pub fn write_file_for_agent(
+        &self,
+        agent: &AgentId,
+        path: &str,
+        data: &[u8],
+    ) -> Result<(), Error> {
+        let c_path = CString::new(path)?;
+        let agent_bytes = agent.0.as_bytes();
+        // SAFETY: handle valid; agent/path/data lifetimes outlive the call.
+        let rc = unsafe {
+            sys::helios_vst_write_file_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                c_path.as_ptr(),
+                if data.is_empty() { ptr::null() } else { data.as_ptr() },
+                data.len(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Read `agent`'s working-set content at `path`. Returns Ok(None) if absent.
+    pub fn read_file_for_agent(
+        &self,
+        agent: &AgentId,
+        path: &str,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let c_path = CString::new(path)?;
+        let agent_bytes = agent.0.as_bytes();
+        let mut buf: *mut u8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params are owned locals.
+        let rc = unsafe {
+            sys::helios_vst_read_file_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                c_path.as_ptr(),
+                &mut buf,
+                &mut len,
+            )
+        };
+        rc_to_result(rc)?;
+        Ok(copy_owned_buffer(buf, len))
+    }
+
+    /// Delete `path` from `agent`'s working set (no-op if absent).
+    pub fn delete_file_for_agent(&self, agent: &AgentId, path: &str) -> Result<(), Error> {
+        let c_path = CString::new(path)?;
+        let agent_bytes = agent.0.as_bytes();
+        // SAFETY: handle valid; agent/path lifetimes outlive the call.
+        let rc = unsafe {
+            sys::helios_vst_delete_file_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                c_path.as_ptr(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Commit `agent`'s working set and return the new SnapshotId.
+    pub fn commit_for_agent(&self, agent: &AgentId, msg: &str) -> Result<SnapshotId, Error> {
+        let c_msg = CString::new(msg)?;
+        let agent_bytes = agent.0.as_bytes();
+        let mut out: *mut i8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params are owned locals.
+        let rc = unsafe {
+            sys::helios_vst_commit_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                c_msg.as_ptr(),
+                &mut out,
+                &mut len,
+            )
+        };
+        rc_to_result(rc)?;
+        Ok(SnapshotId(copy_owned_string(out, len)))
+    }
+
+    /// Restore a committed snapshot into `agent`'s working set (memory only;
+    /// no filesystem materialisation).
+    pub fn restore_for_agent(&self, agent: &AgentId, id: &SnapshotId) -> Result<(), Error> {
+        let agent_bytes = agent.0.as_bytes();
+        let id_bytes = id.0.as_bytes();
+        // SAFETY: handle valid; agent/id lifetimes outlive the call.
+        let rc = unsafe {
+            sys::helios_vst_restore_memory_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                id_bytes.as_ptr() as *const i8,
+                id_bytes.len(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Register a named branch in `agent`'s namespace pointing at `head`.
+    pub fn create_branch_for_agent(
+        &self,
+        agent: &AgentId,
+        name: &BranchId,
+        head: &SnapshotId,
+    ) -> Result<(), Error> {
+        let c_name = CString::new(name.0.as_str())?;
+        let agent_bytes = agent.0.as_bytes();
+        let head_bytes = head.0.as_bytes();
+        // SAFETY: handle valid; agent/name/head lifetimes outlive the call.
+        let rc = unsafe {
+            sys::helios_vst_create_branch_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                c_name.as_ptr(),
+                head_bytes.as_ptr() as *const i8,
+                head_bytes.len(),
+            )
+        };
+        rc_to_result(rc)
+    }
+
+    /// Return the current head SnapshotId for a branch in `agent`'s namespace,
+    /// or None if unknown.
+    pub fn branch_head_for_agent(
+        &self,
+        agent: &AgentId,
+        name: &BranchId,
+    ) -> Result<Option<SnapshotId>, Error> {
+        let c_name = CString::new(name.0.as_str())?;
+        let agent_bytes = agent.0.as_bytes();
+        let mut out: *mut i8 = ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: handle valid; out params are owned locals.
+        let rc = unsafe {
+            sys::helios_vst_branch_head_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                c_name.as_ptr(),
+                &mut out,
+                &mut len,
+            )
+        };
+        match rc_to_result(rc) {
+            Ok(()) => Ok(Some(SnapshotId(copy_owned_string(out, len)))),
+            Err(Error::NotFound) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Open a copy-on-write Fork in `agent`'s namespace rooted at `base`.
+    pub fn fork_for_agent(&self, agent: &AgentId, base: &SnapshotId) -> Result<Fork<'_>, Error> {
+        let agent_bytes = agent.0.as_bytes();
+        let base_bytes = base.0.as_bytes();
+        let mut fh: sys::helios_fork_t = 0;
+        // SAFETY: handle valid; out param is an owned local.
+        let rc = unsafe {
+            sys::helios_fork_new_for_agent(
+                self.handle,
+                if agent_bytes.is_empty() { ptr::null() } else { agent_bytes.as_ptr() as *const i8 },
+                agent_bytes.len(),
+                base_bytes.as_ptr() as *const i8,
+                base_bytes.len(),
                 &mut fh,
             )
         };
@@ -441,6 +668,79 @@ mod tests {
             "Fork overlay: empty file must be Some(vec![]) not None"
         );
         f.discard();
+    }
+
+    // PR-VA-1a: multi-tenant isolation across the FFI. A write under one
+    // AgentId must not be visible to a different AgentId, and the legacy
+    // non-agent API must alias the same tenant as AgentId::default()
+    // ("default"), because the Go side normalises "" -> AGENT_DEFAULT.
+    #[test]
+    fn test_agent_tenant_roundtrip_isolation() {
+        let v = Vst::new();
+        let alice: AgentId = "alice".into();
+        let bob: AgentId = "bob".into();
+
+        // Round-trip: alice writes, alice reads her own bytes back.
+        v.write_file_for_agent(&alice, "secret.txt", b"alice-data").unwrap();
+        assert_eq!(
+            v.read_file_for_agent(&alice, "secret.txt").unwrap(),
+            Some(b"alice-data".to_vec()),
+            "alice must read her own write"
+        );
+
+        // Isolation: bob cannot see alice's path (absent -> None, not bytes).
+        assert_eq!(
+            v.read_file_for_agent(&bob, "secret.txt").unwrap(),
+            None,
+            "bob must NOT see alice's file (tenant isolation)"
+        );
+
+        // Bob's independent write to the same path does not leak into alice.
+        v.write_file_for_agent(&bob, "secret.txt", b"bob-data").unwrap();
+        assert_eq!(
+            v.read_file_for_agent(&bob, "secret.txt").unwrap(),
+            Some(b"bob-data".to_vec()),
+            "bob reads his own write"
+        );
+        assert_eq!(
+            v.read_file_for_agent(&alice, "secret.txt").unwrap(),
+            Some(b"alice-data".to_vec()),
+            "alice's data is unchanged by bob's write to the same path"
+        );
+
+        // Legacy non-agent API aliases the "default" tenant, both directions.
+        v.write_file("legacy.txt", b"legacy").unwrap();
+        assert_eq!(
+            v.read_file_for_agent(&AgentId::default(), "legacy.txt").unwrap(),
+            Some(b"legacy".to_vec()),
+            "legacy WriteFile must be visible under AgentId::default()"
+        );
+        v.write_file_for_agent(&AgentId::default(), "default_write.txt", b"d").unwrap();
+        assert_eq!(
+            v.read_file("default_write.txt").unwrap(),
+            Some(b"d".to_vec()),
+            "default-tenant write must be visible via the legacy ReadFile"
+        );
+
+        // The default tenant is itself isolated from the named tenants.
+        assert_eq!(
+            v.read_file_for_agent(&alice, "legacy.txt").unwrap(),
+            None,
+            "alice must be isolated from the default tenant"
+        );
+
+        // Delete under one agent does not affect another agent's same-named path.
+        v.delete_file_for_agent(&bob, "secret.txt").unwrap();
+        assert_eq!(
+            v.read_file_for_agent(&bob, "secret.txt").unwrap(),
+            None,
+            "bob's delete removes bob's file"
+        );
+        assert_eq!(
+            v.read_file_for_agent(&alice, "secret.txt").unwrap(),
+            Some(b"alice-data".to_vec()),
+            "bob's delete must NOT touch alice's same-named path"
+        );
     }
 
     #[test]

--- a/cmd/heliosffi/main.go
+++ b/cmd/heliosffi/main.go
@@ -220,6 +220,15 @@ func helios_vst_free(h C.uint64_t) C.int {
 
 //export helios_vst_write_file
 func helios_vst_write_file(h C.uint64_t, path *C.char, data *C.uchar, length C.size_t) C.int {
+	return writeFileImpl(h, "", path, data, length)
+}
+
+//export helios_vst_write_file_for_agent
+func helios_vst_write_file_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, path *C.char, data *C.uchar, length C.size_t) C.int {
+	return writeFileImpl(h, goStringFromCN(agentPtr, agentLen), path, data, length)
+}
+
+func writeFileImpl(h C.uint64_t, agent string, path *C.char, data *C.uchar, length C.size_t) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
@@ -227,12 +236,13 @@ func helios_vst_write_file(h C.uint64_t, path *C.char, data *C.uchar, length C.s
 	if path == nil {
 		return cErrInvalidArg
 	}
-	// Copy the C bytes into a Go-owned slice (VST.WriteFile already copies but
-	// this keeps the contract explicit and avoids retaining the C pointer).
+	// Copy the C bytes into a Go-owned slice (VST.WriteFileForAgent already
+	// copies but this keeps the contract explicit and avoids retaining the
+	// C pointer.)
 	src := goBytesFromC(data, length)
 	cp := make([]byte, len(src))
 	copy(cp, src)
-	if err := v.WriteFile(goStringFromC(path), cp); err != nil {
+	if err := v.WriteFileForAgent(vst.AgentId(agent), goStringFromC(path), cp); err != nil {
 		return cErrInternal
 	}
 	return cOK
@@ -240,6 +250,15 @@ func helios_vst_write_file(h C.uint64_t, path *C.char, data *C.uchar, length C.s
 
 //export helios_vst_read_file
 func helios_vst_read_file(h C.uint64_t, path *C.char, outBuf **C.uchar, outLen *C.size_t) C.int {
+	return readFileImpl(h, "", path, outBuf, outLen)
+}
+
+//export helios_vst_read_file_for_agent
+func helios_vst_read_file_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, path *C.char, outBuf **C.uchar, outLen *C.size_t) C.int {
+	return readFileImpl(h, goStringFromCN(agentPtr, agentLen), path, outBuf, outLen)
+}
+
+func readFileImpl(h C.uint64_t, agent string, path *C.char, outBuf **C.uchar, outLen *C.size_t) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
@@ -247,7 +266,7 @@ func helios_vst_read_file(h C.uint64_t, path *C.char, outBuf **C.uchar, outLen *
 	if path == nil {
 		return cErrInvalidArg
 	}
-	b, err := v.ReadFile(goStringFromC(path))
+	b, err := v.ReadFileForAgent(vst.AgentId(agent), goStringFromC(path))
 	if err != nil {
 		return cErrInternal
 	}
@@ -256,6 +275,15 @@ func helios_vst_read_file(h C.uint64_t, path *C.char, outBuf **C.uchar, outLen *
 
 //export helios_vst_delete_file
 func helios_vst_delete_file(h C.uint64_t, path *C.char) C.int {
+	return deleteFileImpl(h, "", path)
+}
+
+//export helios_vst_delete_file_for_agent
+func helios_vst_delete_file_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, path *C.char) C.int {
+	return deleteFileImpl(h, goStringFromCN(agentPtr, agentLen), path)
+}
+
+func deleteFileImpl(h C.uint64_t, agent string, path *C.char) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
@@ -263,7 +291,7 @@ func helios_vst_delete_file(h C.uint64_t, path *C.char) C.int {
 	if path == nil {
 		return cErrInvalidArg
 	}
-	v.DeleteFile(goStringFromC(path))
+	v.DeleteFileForAgent(vst.AgentId(agent), goStringFromC(path))
 	return cOK
 }
 
@@ -273,11 +301,20 @@ func helios_vst_delete_file(h C.uint64_t, path *C.char) C.int {
 
 //export helios_vst_commit
 func helios_vst_commit(h C.uint64_t, msg *C.char, outID **C.char, outLen *C.size_t) C.int {
+	return commitImpl(h, "", msg, outID, outLen)
+}
+
+//export helios_vst_commit_for_agent
+func helios_vst_commit_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, msg *C.char, outID **C.char, outLen *C.size_t) C.int {
+	return commitImpl(h, goStringFromCN(agentPtr, agentLen), msg, outID, outLen)
+}
+
+func commitImpl(h C.uint64_t, agent string, msg *C.char, outID **C.char, outLen *C.size_t) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
 	}
-	id, _, err := v.Commit(goStringFromC(msg))
+	id, _, err := v.CommitForAgent(vst.AgentId(agent), goStringFromC(msg))
 	if err != nil {
 		return cErrInternal
 	}
@@ -286,6 +323,15 @@ func helios_vst_commit(h C.uint64_t, msg *C.char, outID **C.char, outLen *C.size
 
 //export helios_vst_restore_memory
 func helios_vst_restore_memory(h C.uint64_t, id *C.char, idLen C.size_t) C.int {
+	return restoreMemoryImpl(h, "", id, idLen)
+}
+
+//export helios_vst_restore_memory_for_agent
+func helios_vst_restore_memory_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, id *C.char, idLen C.size_t) C.int {
+	return restoreMemoryImpl(h, goStringFromCN(agentPtr, agentLen), id, idLen)
+}
+
+func restoreMemoryImpl(h C.uint64_t, agent string, id *C.char, idLen C.size_t) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
@@ -293,7 +339,7 @@ func helios_vst_restore_memory(h C.uint64_t, id *C.char, idLen C.size_t) C.int {
 	sid := types.SnapshotID(goStringFromCN(id, idLen))
 	// In-memory restore only: bypass filesystem materialisation so the FFI
 	// path is suitable for hot agent loops (no PWD coupling, no atomic-rename).
-	if err := v.RestoreWithOpts(sid, types.RestoreOpts{DryRun: false, WriteToFilesystem: false}); err != nil {
+	if err := v.RestoreForAgent(vst.AgentId(agent), sid, types.RestoreOpts{DryRun: false, WriteToFilesystem: false}); err != nil {
 		return cErrNotFound
 	}
 	return cOK
@@ -305,6 +351,15 @@ func helios_vst_restore_memory(h C.uint64_t, id *C.char, idLen C.size_t) C.int {
 
 //export helios_vst_create_branch
 func helios_vst_create_branch(h C.uint64_t, name *C.char, head *C.char, headLen C.size_t) C.int {
+	return createBranchImpl(h, "", name, head, headLen)
+}
+
+//export helios_vst_create_branch_for_agent
+func helios_vst_create_branch_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, name *C.char, head *C.char, headLen C.size_t) C.int {
+	return createBranchImpl(h, goStringFromCN(agentPtr, agentLen), name, head, headLen)
+}
+
+func createBranchImpl(h C.uint64_t, agent string, name *C.char, head *C.char, headLen C.size_t) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
@@ -312,7 +367,7 @@ func helios_vst_create_branch(h C.uint64_t, name *C.char, head *C.char, headLen 
 	if name == nil {
 		return cErrInvalidArg
 	}
-	err := v.CreateBranch(vst.BranchID(goStringFromC(name)), types.SnapshotID(goStringFromCN(head, headLen)))
+	err := v.CreateBranchForAgent(vst.AgentId(agent), vst.BranchID(goStringFromC(name)), types.SnapshotID(goStringFromCN(head, headLen)))
 	switch err {
 	case nil:
 		return cOK
@@ -325,11 +380,20 @@ func helios_vst_create_branch(h C.uint64_t, name *C.char, head *C.char, headLen 
 
 //export helios_vst_branch_head
 func helios_vst_branch_head(h C.uint64_t, name *C.char, outID **C.char, outLen *C.size_t) C.int {
+	return branchHeadImpl(h, "", name, outID, outLen)
+}
+
+//export helios_vst_branch_head_for_agent
+func helios_vst_branch_head_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, name *C.char, outID **C.char, outLen *C.size_t) C.int {
+	return branchHeadImpl(h, goStringFromCN(agentPtr, agentLen), name, outID, outLen)
+}
+
+func branchHeadImpl(h C.uint64_t, agent string, name *C.char, outID **C.char, outLen *C.size_t) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
 	}
-	id, ok := v.BranchHead(vst.BranchID(goStringFromC(name)))
+	id, ok := v.BranchHeadForAgent(vst.AgentId(agent), vst.BranchID(goStringFromC(name)))
 	if !ok {
 		return cErrNotFound
 	}
@@ -342,6 +406,15 @@ func helios_vst_branch_head(h C.uint64_t, name *C.char, outID **C.char, outLen *
 
 //export helios_fork_new
 func helios_fork_new(h C.uint64_t, base *C.char, baseLen C.size_t, outForkHdl *C.uint64_t) C.int {
+	return forkNewImpl(h, "", base, baseLen, outForkHdl)
+}
+
+//export helios_fork_new_for_agent
+func helios_fork_new_for_agent(h C.uint64_t, agentPtr *C.char, agentLen C.size_t, base *C.char, baseLen C.size_t, outForkHdl *C.uint64_t) C.int {
+	return forkNewImpl(h, goStringFromCN(agentPtr, agentLen), base, baseLen, outForkHdl)
+}
+
+func forkNewImpl(h C.uint64_t, agent string, base *C.char, baseLen C.size_t, outForkHdl *C.uint64_t) C.int {
 	v := lookupVST(uint64(h))
 	if v == nil {
 		return cErrInvalidHdl
@@ -349,7 +422,7 @@ func helios_fork_new(h C.uint64_t, base *C.char, baseLen C.size_t, outForkHdl *C
 	if outForkHdl == nil {
 		return cErrInvalidArg
 	}
-	f, err := v.Fork(types.SnapshotID(goStringFromCN(base, baseLen)))
+	f, err := v.ForkForAgent(vst.AgentId(agent), types.SnapshotID(goStringFromCN(base, baseLen)))
 	if err != nil {
 		return cErrNotFound
 	}


### PR DESCRIPTION
## What

Thread the multi-tenant `AgentId` through the Rust/CGO FFI layer, matching the
Go-side `AgentId` thread-through merged in #46 (PR-VA-1a). Adds per-agent
`*_for_agent` FFI variants so multi-tenant callers can target a specific tenant
in the VST namespace; the legacy non-agent symbols keep targeting the `"default"`
tenant unchanged.

## Changes (3 in-scope files)

- **cmd/heliosffi/main.go** — export `helios_*_for_agent` CGO symbols
  (write/read/delete file, commit, restore_memory, create_branch, branch_head,
  fork_new) via shared `*Impl` helpers. Legacy symbols delegate with `agent=""`,
  which the Go core normalises to `"default"`, so their behaviour is byte-identical.
- **bindings/rust/helios-sys/src/lib.rs** — matching `extern "C"`
  `helios_*_for_agent` declarations (ABI-parallel to the Go exports).
- **bindings/rust/src/lib.rs** — `AgentId(String)` newtype
  (`AGENT_DEFAULT="default"`, `From`/`Default`/`Display`) + per-agent safe
  wrappers. `AgentId` crosses FFI as a `(ptr,len)` pair (interior-NUL safe;
  empty → `NULL/0` → `"default"`). Adds `test_agent_tenant_roundtrip_isolation`.

## Definition of done — verified

| Gate | Result |
|------|--------|
| `go build ./cmd/heliosffi` + `go vet` | clean (exit 0) |
| `go build -buildmode=c-archive` | clean (exit 0) |
| `cargo test --manifest-path bindings/rust/Cargo.toml` | **4 passed / 0 failed** |
| Files modified | exactly the 3 in-scope FFI files |
| New suppressions | none |

Tests: `test_agent_tenant_roundtrip_isolation`, `test_empty_file_roundtrip_vst`,
`end_to_end_fork_merge`, `stale_cas_returns_branch_stale`.

## Verification notes

- The tenant-isolation test exercises `write/read/delete_file_for_agent`; a
  missing/mis-named `for_agent` symbol would fail the static link, so a green
  link+run proves the symbols exist and marshal correctly.
- All 8 `for_agent` C-ABI signatures hand-checked Go↔Rust (arg count/order/
  pointer-ness/size types) and `nm`-confirmed as exported `T` symbols; the 5 not
  runtime-exercised by the test (commit/restore/create_branch/branch_head/
  fork_new) were checked this way since C links resolve by name only.
- Tenant isolation is enforced by the Go core's per-`agentState` partitioning
  (out of scope here); the legacy↔`default` aliasing relies on the core's
  empty-string → `AGENT_DEFAULT` normalisation, asserted both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
