### PR TITLE
fix(vst): restore reconciles the working tree with the snapshot (deletes stale files)

### DIFF
--- a/pkg/helios/vst/vst.go
+++ b/pkg/helios/vst/vst.go
@@ -18,6 +18,7 @@ package vst
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -463,6 +464,14 @@ func (v *VST) RestoreForAgent(agent AgentId, id types.SnapshotID, opts types.Res
 			oldTrackedFiles[path] = true
 		}
 	}
+	// hadInMemoryTracking records whether the agent had a known working set at the
+	// start of restore. When true we prune precisely via oldTrackedFiles (below).
+	// When false — a cold process where nothing has been committed/restored
+	// in-process — oldTrackedFiles is empty, the precise prune catches nothing,
+	// and we fall back to a filesystem walk to reconcile the working tree with the
+	// snapshot. Gating the walk on this flag keeps in-process/library callers
+	// (whose working set is populated) from ever pruning unrelated CWD contents.
+	hadInMemoryTracking := len(oldTrackedFiles) > 0
 	v.mu.RUnlock()
 
 	if !ok && v.l2 == nil {
@@ -577,7 +586,9 @@ func (v *VST) RestoreForAgent(agent AgentId, id types.SnapshotID, opts types.Res
 			dprintf("restored file %s (%d bytes)", path, len(content))
 		}
 		
-		// Clean up stale files that were tracked before but are not in the restored snapshot
+		// Clean up stale files that were tracked before but are not in the restored
+		// snapshot. Precise path: only touches files the in-memory working set knew
+		// about, so it never removes unrelated CWD contents.
 		for stalePath := range oldTrackedFiles {
 			fullPath := filepath.Join(cwd, stalePath)
 			if err := os.Remove(fullPath); err != nil {
@@ -586,6 +597,47 @@ func (v *VST) RestoreForAgent(agent AgentId, id types.SnapshotID, opts types.Res
 			} else {
 				dprintf("removed stale file %s", stalePath)
 			}
+		}
+
+		// Cold-process fallback. When the agent had no in-memory working set,
+		// oldTrackedFiles was empty and the precise prune above caught nothing, so
+		// files present on disk but absent from the snapshot would leak in (the
+		// vst.go:459-465 root cause). Reconcile by walking cwd and removing any
+		// regular file whose slash-normalized path relative to cwd is not a key of
+		// restoredContent, making the working tree MATCH the snapshot. Skip .git/
+		// and .helios/ exactly like ingest does, and remove only regular files —
+		// never directories, never the object store — preserving the
+		// never-fail-on-cleanup posture above. Gated on !hadInMemoryTracking so
+		// in-process/library callers (whose working set is populated before
+		// restore) never trigger this broad walk.
+		if !hadInMemoryTracking {
+			_ = filepath.WalkDir(cwd, func(p string, d fs.DirEntry, werr error) error {
+				if werr != nil {
+					return werr
+				}
+				if d.IsDir() {
+					if name := d.Name(); name == ".git" || name == ".helios" {
+						return fs.SkipDir
+					}
+					return nil
+				}
+				if !d.Type().IsRegular() {
+					return nil
+				}
+				rel, relErr := filepath.Rel(cwd, p)
+				if relErr != nil {
+					return nil
+				}
+				rel = filepath.ToSlash(rel)
+				if _, keep := restoredContent[rel]; !keep {
+					if err := os.Remove(p); err != nil {
+						dprintf("stale remove failed %s: %v", rel, err)
+					} else {
+						dprintf("pruned stale file %s", rel)
+					}
+				}
+				return nil
+			})
 		}
 	} else if opts.DryRun || !opts.WriteToFilesystem {
 		dprintf("dry-run mode: skipped writing %d files to filesystem", len(restoredContent))

--- a/pkg/helios/vst/vst_restore_stale_test.go
+++ b/pkg/helios/vst/vst_restore_stale_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vst
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/good-night-oppie/helios/pkg/helios/l1cache"
+	"github.com/good-night-oppie/helios/pkg/helios/objstore"
+	"github.com/good-night-oppie/helios/pkg/helios/types"
+)
+
+// newStaleTestL1 builds a small L1 cache for the test engines.
+func newStaleTestL1(t *testing.T) l1cache.Cache {
+	t.Helper()
+	l1, err := l1cache.New(l1cache.Config{CapacityBytes: 8 << 20, CompressionThreshold: 256})
+	if err != nil {
+		t.Fatalf("l1cache.New: %v", err)
+	}
+	return l1
+}
+
+// openStaleTestStore opens the shared L2 object store. Pebble is single-writer,
+// so each engine must Close() before the next opens the same directory.
+func openStaleTestStore(t *testing.T, dir string) objstore.Store {
+	t.Helper()
+	l2, err := objstore.Open(dir, nil)
+	if err != nil {
+		t.Fatalf("objstore.Open(%s): %v", dir, err)
+	}
+	return l2
+}
+
+// TestRestore_DeletesStaleFiles reproduces the cold-CLI-process condition
+// (snapshot lives only in L2, the agent working set is empty) and proves that
+// restore makes the working tree MATCH the snapshot — i.e. it deletes files
+// that are present on disk but absent from the restored snapshot.
+//
+// Root cause (pre-fix): RestoreForAgent seeds oldTrackedFiles from the
+// in-memory agent working set (vst.go:459-465), which is always empty in a
+// fresh process, so the stale-file cleanup loop (vst.go:581-589) iterates over
+// nothing and sibling files leak in.
+//
+// The test isolates CWD into a temp dir (save/restore manually — no t.Chdir,
+// go.mod pins go 1.22) so the cold-process reconcile walk is contained.
+func TestRestore_DeletesStaleFiles(t *testing.T) {
+	store := t.TempDir() // shared L2 object store
+
+	// S1 = {keep.txt, gone.txt}
+	vA := New()
+	vA.AttachStores(newStaleTestL1(t), openStaleTestStore(t, store))
+	if err := vA.WriteFile("keep.txt", []byte("K")); err != nil {
+		t.Fatalf("write keep: %v", err)
+	}
+	if err := vA.WriteFile("gone.txt", []byte("G")); err != nil {
+		t.Fatalf("write gone: %v", err)
+	}
+	s1, _, err := vA.Commit("s1")
+	if err != nil {
+		t.Fatalf("commit s1: %v", err)
+	}
+	if err := vA.Close(); err != nil {
+		t.Fatalf("close vA: %v", err)
+	}
+
+	// S2 = {keep.txt} only, into the SAME content-addressed store.
+	vB := New()
+	vB.AttachStores(newStaleTestL1(t), openStaleTestStore(t, store))
+	if err := vB.WriteFile("keep.txt", []byte("K")); err != nil {
+		t.Fatalf("write keep (B): %v", err)
+	}
+	s2, _, err := vB.Commit("s2")
+	if err != nil {
+		t.Fatalf("commit s2: %v", err)
+	}
+	if err := vB.Close(); err != nil {
+		t.Fatalf("close vB: %v", err)
+	}
+
+	// Cold restore: a FRESH engine with an empty working set. Materialize S1 to
+	// populate the working dir (keep.txt + gone.txt), then restore S2 and expect
+	// gone.txt to be pruned.
+	work := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(old) }()
+
+	vC := New()
+	vC.AttachStores(newStaleTestL1(t), openStaleTestStore(t, store))
+	defer vC.Close()
+	if _, err := vC.Materialize(s1, work, types.MatOpts{}); err != nil {
+		t.Fatalf("materialize s1: %v", err)
+	}
+	// Sanity: the stale file exists on disk before restore.
+	if _, err := os.Stat(filepath.Join(work, "gone.txt")); err != nil {
+		t.Fatalf("precondition: gone.txt should exist after materialize: %v", err)
+	}
+
+	if err := os.Chdir(work); err != nil {
+		t.Fatalf("chdir work: %v", err)
+	}
+	if err := vC.Restore(s2); err != nil {
+		t.Fatalf("restore s2: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(work, "keep.txt")); err != nil {
+		t.Fatalf("keep.txt missing after restore: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "gone.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale gone.txt was not deleted by restore (err=%v)", err)
+	}
+}


### PR DESCRIPTION
## Problem
`RestoreForAgent` seeds `oldTrackedFiles` from the in-memory agent working set (**`pkg/helios/vst/vst.go:459-465`**). In a **cold CLI process** nothing has been committed/restored in-process, so `s.cur` is empty, `oldTrackedFiles` is empty, and the stale-file cleanup loop (**`vst.go:581-589`**) iterates over nothing. `restore` then behaves as a merge that **never deletes** files present on disk but absent from the snapshot — sibling-branch files leak into the working tree.

## Fix
Keep the precise `oldTrackedFiles` prune for the in-process path, and add a **cold-process fallback**: when the agent had no in-memory working set (`hadInMemoryTracking == false`), walk `cwd` after writing `restoredContent` and remove any regular file whose slash-normalized path relative to `cwd` is not in the snapshot, making the working tree **match** the snapshot. Skips `.git/` and `.helios/` (like ingest), removes only regular files (never directories, never the object store), preserves the never-fail-on-cleanup posture. The broad walk is **gated on `!hadInMemoryTracking`** so in-process/library callers (whose working set is populated by `WriteFile` before `Restore`) never trigger a CWD-wide prune — only a genuinely cold `helios restore` reconciles against the filesystem.

## Test (RED → GREEN)
`TestRestore_DeletesStaleFiles` (`pkg/helios/vst/vst_restore_stale_test.go`) reproduces the cold-process condition (snapshot only in L2, empty agent working set): materialize `S1={keep.txt,gone.txt}` into a fresh dir, restore `S2={keep.txt}`, assert `gone.txt` is pruned. **RED** on old code (`gone.txt` survives), **GREEN** after. CWD is isolated into a temp dir with manual save/restore (no `t.Chdir` — go.mod pins go 1.22).

## Note
This is **upstream hygiene**. It does **not** change the AI-Scientist-v2 integration's use of `materialize --out <fresh dir>` as its reconstruction primitive; that decision stands. This PR does not reopen the restore-vs-materialize choice.