### PR TITLE
fix(cli): consistent store resolution between commit and materialize/diff/stats

### DIFF
--- a/cmd/helios-cli/cli_smoke_test.go
+++ b/cmd/helios-cli/cli_smoke_test.go
@@ -15,12 +15,30 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 )
+
+// runCLIStdout runs the built CLI and returns only its STDOUT. Commit/stats emit
+// their JSON result on stdout; Pebble WAL-replay chatter goes to stderr (which
+// happens whenever the resolved store already exists — e.g. once commit and
+// stats share the same store directory). Parsing stdout only keeps the JSON
+// assertions robust to that stderr noise; stderr is surfaced on failure.
+func runCLIStdout(t *testing.T, bin string, args ...string) []byte {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("%s %v failed: %v\nstderr:\n%s", bin, args, err, stderr.String())
+	}
+	return stdout.Bytes()
+}
 
 // We only assert "shape", not long strings, to keep golden stable.
 func TestCLI_CommitAndStats_Smoke(t *testing.T) {
@@ -34,10 +52,7 @@ func TestCLI_CommitAndStats_Smoke(t *testing.T) {
 
 	// Run `commit` on an empty work dir; CLI should not panic and must print JSON
 	work := t.TempDir()
-	outC, err := exec.Command(bin, "commit", "--work", work).CombinedOutput()
-	if err != nil {
-		t.Fatalf("commit failed: %v\n%s", err, string(outC))
-	}
+	outC := runCLIStdout(t, bin, "commit", "--work", work)
 	var jc map[string]any
 	if err := json.Unmarshal(outC, &jc); err != nil {
 		t.Fatalf("commit output is not JSON: %v\n%s", err, string(outC))
@@ -47,10 +62,7 @@ func TestCLI_CommitAndStats_Smoke(t *testing.T) {
 	}
 
 	// `stats` should be valid JSON and contain a top-level "l1"
-	outS, err := exec.Command(bin, "stats").CombinedOutput()
-	if err != nil {
-		t.Fatalf("stats failed: %v\n%s", err, string(outS))
-	}
+	outS := runCLIStdout(t, bin, "stats")
 	var js map[string]any
 	if err := json.Unmarshal(outS, &js); err != nil {
 		t.Fatalf("stats output is not JSON: %v\n%s", err, string(outS))

--- a/cmd/helios-cli/internal/cli/cli.go
+++ b/cmd/helios-cli/internal/cli/cli.go
@@ -56,23 +56,31 @@ type MatOpts struct {
 	Exclude []string
 }
 
-// HandleCommit processes commit command
+// HandleCommit processes commit command.
+//
+// Store resolution must be identical to materialize/diff/stats, which never
+// change directory: those resolve the store from the real invocation CWD via
+// DefaultEngineFactory -> os.Getwd() -> cli.ResolveStore. Previously HandleCommit
+// os.Chdir'd into workDir *before* the factory ran, so `commit --work W` wrote
+// the store under W/.helios/objects while materialize looked under
+// <invocation-CWD>/.helios/objects — the two disagreed and the commit was
+// unreadable unless HELIOS_STORE_DIR was set. Instead of chdir'ing, resolve the
+// engine (and thus the store) from the true CWD and ingest from workDir
+// explicitly.
 func HandleCommit(w io.Writer, cfg Config, workDir string) error {
-	if workDir != "" {
-		if err := os.Chdir(workDir); err != nil {
-			return fmt.Errorf("work dir: %w", err)
-		}
-	}
-
-	eng, err := cfg.EngineFactory()
+	eng, err := cfg.EngineFactory() // resolves the store from the real CWD, exactly like materialize
 	if err != nil {
 		return err
 	}
 	defer eng.Close()
 
-	// Ingest current working directory into the engine before committing.
-	// This populates v.cur so that Commit() has real blobs to persist into L2.
-	if err := ingestCurrentDir(eng); err != nil {
+	// Ingest the working directory into the engine before committing so Commit()
+	// has real blobs to persist into L2. An empty workDir means the current dir.
+	root := workDir
+	if root == "" {
+		root = "."
+	}
+	if err := ingestDir(eng, root); err != nil {
 		return err
 	}
 
@@ -87,12 +95,12 @@ func HandleCommit(w io.Writer, cfg Config, workDir string) error {
 	return json.NewEncoder(w).Encode(out)
 }
 
-// ingestCurrentDir walks the current working dir and writes regular files
-// into the engine using relative, slash-normalized paths.
-// Skips internal folders like .git and .helios.
-func ingestCurrentDir(eng interface{ WriteFile(string, []byte) error }) error {
-    root, err := os.Getwd()
-    if err != nil { return err }
+// ingestDir walks root and writes regular files into the engine using relative,
+// slash-normalized paths. Skips internal folders like .git and .helios. root is
+// taken explicitly (rather than os.Getwd()) so the caller controls which tree is
+// ingested without changing the process working directory — keeping store
+// resolution consistent across commands.
+func ingestDir(eng interface{ WriteFile(string, []byte) error }, root string) error {
     skip := map[string]struct{}{".git": {}, ".helios": {}}
 
     return filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {

--- a/cmd/helios-cli/internal/cli/cli_store_resolution_test.go
+++ b/cmd/helios-cli/internal/cli/cli_store_resolution_test.go
@@ -1,0 +1,160 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// saveStoreEnv unsets HELIOS_STORE_DIR (or sets it to want) for the duration of
+// a test and restores the prior value on cleanup. Passing want == "" unsets it.
+func saveStoreEnv(t *testing.T, want string) {
+	t.Helper()
+	prev, had := os.LookupEnv("HELIOS_STORE_DIR")
+	if want == "" {
+		_ = os.Unsetenv("HELIOS_STORE_DIR")
+	} else {
+		_ = os.Setenv("HELIOS_STORE_DIR", want)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("HELIOS_STORE_DIR", prev)
+		} else {
+			_ = os.Unsetenv("HELIOS_STORE_DIR")
+		}
+	})
+}
+
+// saveCWD saves the working directory and restores it on cleanup. Manual
+// save/restore is used deliberately (no t.Chdir — go.mod pins go 1.22, and
+// t.Chdir was added in go 1.24).
+func saveCWD(t *testing.T) string {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+	return old
+}
+
+// snapshotIDFromJSON json-decodes commit output and returns snapshot_id. The
+// README's `.decode().strip()` idiom is buggy — parse the JSON.
+func snapshotIDFromJSON(t *testing.T, b []byte) string {
+	t.Helper()
+	var res map[string]any
+	if err := json.Unmarshal(b, &res); err != nil {
+		t.Fatalf("commit output is not JSON (%q): %v", string(b), err)
+	}
+	id, _ := res["snapshot_id"].(string)
+	if id == "" {
+		t.Fatalf("no snapshot_id in commit output: %q", string(b))
+	}
+	return id
+}
+
+// TestStoreResolution_CommitReadableByMaterialize proves that a snapshot
+// committed with `--work W` from an invocation directory C is readable by a
+// later `materialize` invoked from the same C, with HELIOS_STORE_DIR unset.
+//
+// Root cause (pre-fix): HandleCommit chdir'd into workDir before the store was
+// resolved, so `commit --work W` wrote the store under W/.helios/objects, while
+// materialize (which never chdir's) resolved it under C/.helios/objects — the
+// two disagreed and materialize failed with "unknown snapshot in L2".
+//
+// The test re-establishes CWD=C before materialize to faithfully simulate the
+// separate CLI processes (each starts from the shell's invocation dir C).
+func TestStoreResolution_CommitReadableByMaterialize(t *testing.T) {
+	saveStoreEnv(t, "") // HELIOS_STORE_DIR must be UNSET or both paths agree and the bug hides
+	saveCWD(t)
+
+	c := t.TempDir() // invocation dir (shell CWD)
+	w := t.TempDir() // --work dir with content
+	if err := os.WriteFile(filepath.Join(w, "hello.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("seed work file: %v", err)
+	}
+
+	cfg := Config{EngineFactory: DefaultEngineFactory} // REAL factory — the fake never touches the store
+
+	if err := os.Chdir(c); err != nil {
+		t.Fatalf("chdir invocation dir: %v", err)
+	}
+	var commitBuf bytes.Buffer
+	if err := HandleCommit(&commitBuf, cfg, w); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	id := snapshotIDFromJSON(t, commitBuf.Bytes())
+
+	// A fresh CLI process would start again from C, so reset CWD to C before
+	// materialize. On pre-fix code HandleCommit left CWD in W; on fixed code it
+	// never moved — either way materialize must resolve the store from C.
+	if err := os.Chdir(c); err != nil {
+		t.Fatalf("re-chdir invocation dir: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out")
+	var matBuf bytes.Buffer
+	if err := HandleMaterialize(&matBuf, cfg, id, out, MatOpts{}); err != nil {
+		// Pre-fix this fails with "unknown snapshot in L2".
+		t.Fatalf("materialize could not read commit (store-resolution bug): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "hello.txt")); err != nil {
+		t.Fatalf("hello.txt not materialized into out dir: %v", err)
+	}
+}
+
+// TestStoreResolution_HonorsEnvVar is the regression guard the integration pins
+// on: with HELIOS_STORE_DIR set, commit and materialize resolve to that store
+// regardless of CWD, so a commit from one dir is materializable from another.
+// This must keep passing on the fixed code (THINKING constraint 6).
+func TestStoreResolution_HonorsEnvVar(t *testing.T) {
+	store := t.TempDir()
+	saveStoreEnv(t, store)
+	saveCWD(t)
+
+	c := t.TempDir()
+	w := t.TempDir()
+	if err := os.WriteFile(filepath.Join(w, "hello.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("seed work file: %v", err)
+	}
+
+	cfg := Config{EngineFactory: DefaultEngineFactory}
+
+	if err := os.Chdir(c); err != nil {
+		t.Fatalf("chdir commit dir: %v", err)
+	}
+	var commitBuf bytes.Buffer
+	if err := HandleCommit(&commitBuf, cfg, w); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	id := snapshotIDFromJSON(t, commitBuf.Bytes())
+
+	// Materialize from a DIFFERENT cwd; the env-pinned store must still resolve.
+	c2 := t.TempDir()
+	if err := os.Chdir(c2); err != nil {
+		t.Fatalf("chdir materialize dir: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out")
+	var matBuf bytes.Buffer
+	if err := HandleMaterialize(&matBuf, cfg, id, out, MatOpts{}); err != nil {
+		t.Fatalf("materialize with HELIOS_STORE_DIR set failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "hello.txt")); err != nil {
+		t.Fatalf("hello.txt not materialized with pinned store: %v", err)
+	}
+}

--- a/pkg/cli/storeutil_test.go
+++ b/pkg/cli/storeutil_test.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Oppie Thunder Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withStoreEnv sets or unsets HELIOS_STORE_DIR for the test and restores it.
+func withStoreEnv(t *testing.T, val string, set bool) {
+	t.Helper()
+	prev, had := os.LookupEnv("HELIOS_STORE_DIR")
+	if set {
+		_ = os.Setenv("HELIOS_STORE_DIR", val)
+	} else {
+		_ = os.Unsetenv("HELIOS_STORE_DIR")
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("HELIOS_STORE_DIR", prev)
+		} else {
+			_ = os.Unsetenv("HELIOS_STORE_DIR")
+		}
+	})
+}
+
+// TestResolveStore_HonorsEnvVar: when HELIOS_STORE_DIR is set, ResolveStore
+// returns exactly that path (created if missing) and ignores cwd. This is the
+// pinned-store contract the AI-Scientist integration depends on.
+func TestResolveStore_HonorsEnvVar(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "pinned", "store")
+	withStoreEnv(t, want, true)
+
+	got, err := ResolveStore(t.TempDir()) // cwd arg must be ignored when env is set
+	if err != nil {
+		t.Fatalf("ResolveStore: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ResolveStore = %q, want env value %q", got, want)
+	}
+	if fi, err := os.Stat(got); err != nil || !fi.IsDir() {
+		t.Fatalf("ResolveStore did not create the store dir %q: err=%v", got, err)
+	}
+}
+
+// TestResolveStore_DefaultUnderCWD: with HELIOS_STORE_DIR unset, ResolveStore
+// falls back to <cwd>/.helios/objects and creates it.
+func TestResolveStore_DefaultUnderCWD(t *testing.T) {
+	withStoreEnv(t, "", false)
+
+	cwd := t.TempDir()
+	got, err := ResolveStore(cwd)
+	if err != nil {
+		t.Fatalf("ResolveStore: %v", err)
+	}
+	want := filepath.Join(cwd, ".helios", "objects")
+	if got != want {
+		t.Fatalf("ResolveStore = %q, want default %q", got, want)
+	}
+	if fi, err := os.Stat(got); err != nil || !fi.IsDir() {
+		t.Fatalf("ResolveStore did not create the default store dir %q: err=%v", got, err)
+	}
+}


### PR DESCRIPTION
## Problem
`HandleCommit` `os.Chdir`'d into `--work` **before** `DefaultEngineFactory` resolved the store via `os.Getwd() -> cli.ResolveStore` (**`cmd/helios-cli/internal/cli/cli.go:60-65`, `:228-256`; `pkg/cli/storeutil.go:24-35`**). So `commit --work W` wrote the store under `W/.helios/objects`, while `materialize`/`diff`/`stats` never chdir and resolved it under `<invocation-CWD>/.helios/objects`. The two disagreed: a commit was unreadable afterward (`materialize`/`diff` failed with **`unknown snapshot in L2`**) unless `HELIOS_STORE_DIR` was set.

## Fix (minimal — no factory-signature change, existing fakes keep compiling)
Stop chdir'ing in `HandleCommit`; resolve the engine from the real invocation CWD (identical to `materialize`) and ingest from `workDir` explicitly. `ingestCurrentDir` is generalized to `ingestDir(eng, root)` taking an explicit root instead of `os.Getwd()`; `HandleCommit` passes `root = workDir` (or `"."` when empty).

## Tests (RED → GREEN, REAL `DefaultEngineFactory` — the `FakeEngine` never touches the store)
- `TestStoreResolution_CommitReadableByMaterialize` (`cmd/helios-cli/internal/cli/cli_store_resolution_test.go`): with `HELIOS_STORE_DIR` unset, `commit --work W` from invocation dir `C` then `materialize` from `C` succeeds. **RED** on old code (`unknown snapshot in L2`), **GREEN** after.
- `TestStoreResolution_HonorsEnvVar`: regression guard — with `HELIOS_STORE_DIR` set, commit and materialize from different CWDs still agree (the pinned-store path the integration depends on).
- `pkg/cli/storeutil_test.go`: unit-tests `ResolveStore` (env-set vs default-under-cwd).

Both CLI tests isolate CWD/env with manual save/restore (no `t.Chdir` — go.mod pins go 1.22) and json-decode `snapshot_id` (not `.strip()`).

## Smoke-test follow-on
Because `commit` now shares the invocation-CWD store with `stats`, reopening it emits Pebble WAL-replay chatter on **stderr**; `cli_smoke_test.go` parsed `CombinedOutput` (stdout+stderr) as JSON and broke. It now parses **stdout only** (WAL chatter is stderr-only by contract) and surfaces stderr on error.