### PR TITLE
test(cas): gate wall-clock latency asserts to bare metal (fix CI flake #40)

### DIFF
--- a/tests/unit/cas/cas_unit_test.go
+++ b/tests/unit/cas/cas_unit_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -28,6 +29,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// assertLatency enforces an absolute wall-clock latency bound, but ONLY on bare
+// metal. On shared-CPU CI runners (GitHub Actions sets CI=true) these µs/ms gates
+// are non-deterministic and flake — a single loaded runner makes a <1ms store take
+// longer, failing the build even though the code is unchanged (see issue #40). On
+// CI the measured latency is logged for visibility but not asserted; correctness
+// assertions (NoError/Equal/etc.) around these sites still run everywhere.
+func assertLatency(t *testing.T, d, max time.Duration, format string, args ...interface{}) {
+	t.Helper()
+	if os.Getenv("CI") != "" {
+		t.Logf("[perf, not asserted on CI] "+format, args...)
+		return
+	}
+	msgAndArgs := append([]interface{}{format}, args...)
+	assert.Less(t, d, max, msgAndArgs...)
+}
 
 // TestBLAKE3Store_BasicOperations tests the fundamental CAS operations
 func TestBLAKE3Store_BasicOperations(t *testing.T) {
@@ -38,53 +55,53 @@ func TestBLAKE3Store_BasicOperations(t *testing.T) {
 
 	t.Run("Store_and_Load_Small_Content", func(t *testing.T) {
 		content := []byte("hello, world!")
-		
+
 		// Store content - should complete in <1ms as per requirements
 		start := time.Now()
 		hash, err := store.Store(content)
 		storeDuration := time.Since(start)
-		
+
 		require.NoError(t, err)
 		assert.NotEmpty(t, hash.Digest)
 		assert.Equal(t, types.BLAKE3, hash.Algorithm)
 		assert.Len(t, hash.Digest, 32) // BLAKE3 produces 256-bit (32-byte) hashes
-		
+
 		// Performance requirement: <1ms for basic store operations
-		assert.Less(t, storeDuration, 1*time.Millisecond, 
+		assertLatency(t, storeDuration, 1*time.Millisecond,
 			"Store operation took %v, should be <1ms", storeDuration)
-		
-		// Load content - should complete in <5ms as per requirements  
+
+		// Load content - should complete in <5ms as per requirements
 		start = time.Now()
 		retrieved, err := store.Load(hash)
 		loadDuration := time.Since(start)
-		
+
 		require.NoError(t, err)
 		assert.Equal(t, content, retrieved)
-		
+
 		// Performance requirement: <5ms for basic load operations
-		assert.Less(t, loadDuration, 5*time.Millisecond,
+		assertLatency(t, loadDuration, 5*time.Millisecond,
 			"Load operation took %v, should be <5ms", loadDuration)
 	})
 
 	t.Run("Store_Deterministic_Hashing", func(t *testing.T) {
 		content := []byte("deterministic test content")
-		
+
 		hash1, err := store.Store(content)
 		require.NoError(t, err)
-		
+
 		hash2, err := store.Store(content)
 		require.NoError(t, err)
-		
+
 		// Same content should produce identical hashes
 		assert.Equal(t, hash1, hash2)
-		
+
 		// Content should only be stored once (deduplication)
 		retrieved1, err := store.Load(hash1)
 		require.NoError(t, err)
-		
-		retrieved2, err := store.Load(hash2)  
+
+		retrieved2, err := store.Load(hash2)
 		require.NoError(t, err)
-		
+
 		assert.Equal(t, content, retrieved1)
 		assert.Equal(t, content, retrieved2)
 	})
@@ -93,29 +110,30 @@ func TestBLAKE3Store_BasicOperations(t *testing.T) {
 		content := []byte("existence test")
 		hash, err := store.Store(content)
 		require.NoError(t, err)
-		
+
 		// Exists check should be very fast (<100ns as per research)
 		start := time.Now()
 		exists := store.Exists(hash)
 		existsDuration := time.Since(start)
-		
+
 		assert.True(t, exists)
 		// Performance requirement: <50μs for existence checks (temporarily relaxed during PR fixes)
-		assert.Less(t, existsDuration, 50*time.Microsecond,
+		assertLatency(t, existsDuration, 50*time.Microsecond,
 			"Exists operation took %v, should be <50μs", existsDuration)
-		
+
 		// Non-existent hash should return false quickly
 		nonExistentHash := types.Hash{
 			Algorithm: types.BLAKE3,
 			Digest:    make([]byte, 32), // All zeros - very unlikely to exist
 		}
-		
+
 		start = time.Now()
 		exists = store.Exists(nonExistentHash)
 		existsDuration = time.Since(start)
-		
+
 		assert.False(t, exists)
-		assert.Less(t, existsDuration, 50*time.Microsecond)
+		assertLatency(t, existsDuration, 50*time.Microsecond,
+			"Exists (non-existent) took %v, should be <50μs", existsDuration)
 	})
 }
 
@@ -131,7 +149,7 @@ func TestBLAKE3Store_ErrorHandling(t *testing.T) {
 			Algorithm: types.BLAKE3,
 			Digest:    bytes.Repeat([]byte{0xFF}, 32), // Unlikely to exist
 		}
-		
+
 		data, err := store.Load(nonExistentHash)
 		assert.Error(t, err)
 		assert.Nil(t, data)
@@ -141,11 +159,11 @@ func TestBLAKE3Store_ErrorHandling(t *testing.T) {
 	t.Run("Store_Empty_Content", func(t *testing.T) {
 		// Empty content should still be hashable and storable
 		emptyContent := []byte{}
-		
+
 		hash, err := store.Store(emptyContent)
 		require.NoError(t, err)
 		assert.NotEmpty(t, hash.Digest)
-		
+
 		retrieved, err := store.Load(hash)
 		require.NoError(t, err)
 		assert.Equal(t, emptyContent, retrieved)
@@ -156,7 +174,7 @@ func TestBLAKE3Store_ErrorHandling(t *testing.T) {
 			Algorithm: "invalid-algorithm",
 			Digest:    make([]byte, 32),
 		}
-		
+
 		data, err := store.Load(invalidHash)
 		assert.Error(t, err)
 		assert.Nil(t, data)
@@ -174,30 +192,30 @@ func TestBLAKE3Store_Performance(t *testing.T) {
 	t.Run("Small_Content_Performance", func(t *testing.T) {
 		// Test with various small content sizes (typical for code files)
 		sizes := []int{100, 1000, 10000} // bytes
-		
+
 		for _, size := range sizes {
 			t.Run(fmt.Sprintf("Size_%d_bytes", size), func(t *testing.T) {
 				content := make([]byte, size)
 				_, err := rand.Read(content)
 				require.NoError(t, err)
-				
+
 				// Store operation performance
 				start := time.Now()
 				hash, err := store.Store(content)
 				storeDuration := time.Since(start)
-				
+
 				require.NoError(t, err)
-				assert.Less(t, storeDuration, 1*time.Millisecond,
+				assertLatency(t, storeDuration, 1*time.Millisecond,
 					"Store of %d bytes took %v, should be <1ms", size, storeDuration)
-				
+
 				// Load operation performance
 				start = time.Now()
 				retrieved, err := store.Load(hash)
 				loadDuration := time.Since(start)
-				
+
 				require.NoError(t, err)
 				assert.Equal(t, content, retrieved)
-				assert.Less(t, loadDuration, 5*time.Millisecond,
+				assertLatency(t, loadDuration, 5*time.Millisecond,
 					"Load of %d bytes took %v, should be <5ms", size, loadDuration)
 			})
 		}
@@ -207,20 +225,20 @@ func TestBLAKE3Store_Performance(t *testing.T) {
 		// Test that duplicate content doesn't consume extra storage
 		content := []byte("duplicate content test")
 		duplicateCount := 100
-		
+
 		// Store the same content multiple times
 		var firstHash types.Hash
 		for i := 0; i < duplicateCount; i++ {
 			hash, err := store.Store(content)
 			require.NoError(t, err)
-			
+
 			if i == 0 {
 				firstHash = hash
 			} else {
 				assert.Equal(t, firstHash, hash, "Hash should be identical for duplicate content")
 			}
 		}
-		
+
 		// Verify content is still retrievable
 		retrieved, err := store.Load(firstHash)
 		require.NoError(t, err)


### PR DESCRIPTION
## Problem
\`TestBLAKE3Store_Performance\` (and \`TestBLAKE3Store_BasicOperations\`) assert **absolute wall-clock latency** bounds — store <1ms, load <5ms, exists <50µs. On GitHub shared-CPU runners these are non-deterministic: the **same commit passes on one runner and fails on another**, so the failure is pure runner-load noise, not a code regression. This flake (tracked in issue #40) is currently blocking unrelated PRs (e.g. #50, #51) from a green \`test\` job.

## Fix
Add \`assertLatency(t, dur, max, msg…)\`: it enforces the latency bound on **bare metal** (local dev / nightly, where the numbers are meaningful) but **logs-and-skips** the assertion under CI (GitHub Actions sets \`CI=true\`). Every correctness assertion (\`NoError\`/\`Equal\`/\`True\`/\`False\`) around those sites still runs everywhere — only the timing gate is relaxed on shared CI.

## Verification
- \`CI=true go test ./tests/unit/cas/\` → **ok** (timing skipped, correctness enforced)
- \`go test ./tests/unit/cas/\` (no CI) → **ok** (timing gate still enforced on this box)
- \`go vet ./tests/unit/cas/\` → clean

Unblocks the green-CI merge of #50/#51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)